### PR TITLE
Problem: unable to detect the end of workflow

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,5 +1,9 @@
 package events
 
+import (
+	"bpxe.org/pkg/bpmn"
+)
+
 // Marker trait for process events
 type ProcessEvent interface {
 	processEvent()
@@ -15,10 +19,12 @@ func MakeStartEvent() StartEvent {
 func (ev StartEvent) processEvent() {}
 
 // Process has ended
-type EndEvent struct{}
+type EndEvent struct {
+	Element *bpmn.EndEvent
+}
 
-func MakeEndEvent() EndEvent {
-	return EndEvent{}
+func MakeEndEvent(element *bpmn.EndEvent) EndEvent {
+	return EndEvent{Element: element}
 }
 
 func (ev EndEvent) processEvent() {}

--- a/pkg/flow_node/event/end_event/end_event.go
+++ b/pkg/flow_node/event/end_event/end_event.go
@@ -1,6 +1,8 @@
 package end_event
 
 import (
+	"sync"
+
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/events"
 	"bpxe.org/pkg/flow_node"
@@ -30,7 +32,6 @@ type EndEvent struct {
 	completed            bool
 	eventConsumer        events.ProcessEventConsumer
 	runnerChannel        chan message
-	traces               chan tracing.Trace
 	startEventsActivated []*bpmn.StartEvent
 }
 
@@ -41,13 +42,15 @@ func NewEndEvent(process *bpmn.Process,
 	eventEgress events.ProcessEventSource,
 	tracer *tracing.Tracer,
 	flowNodeMapping *flow_node.FlowNodeMapping,
+	flowWaitGroup *sync.WaitGroup,
 ) (node *EndEvent, err error) {
 	flowNodePtr, err := flow_node.NewFlowNode(
 		process,
 		definitions,
 		&endEvent.FlowNode,
 		eventIngress, eventEgress,
-		tracer, flowNodeMapping)
+		tracer, flowNodeMapping,
+		flowWaitGroup)
 	if err != nil {
 		return
 	}
@@ -59,7 +62,6 @@ func NewEndEvent(process *bpmn.Process,
 		completed:            false,
 		eventConsumer:        eventIngress,
 		runnerChannel:        make(chan message),
-		traces:               flowNode.Tracer.Subscribe(),
 		startEventsActivated: make([]*bpmn.StartEvent, 0),
 	}
 	go node.runner()
@@ -71,63 +73,31 @@ func NewEndEvent(process *bpmn.Process,
 
 func (node *EndEvent) runner() {
 	for {
-		select {
-		case msg := <-node.runnerChannel:
-			switch m := msg.(type) {
-			case incomingMessage:
-				node.activated = true
-			case nextActionMessage:
-				/* 13.4.6 End Events:
-
-				   The Process instance is [...] completed, if
-				   and only if the following two conditions
-				   hold:
-
-				   (1) All start nodes of the Process have been
-				   visited. More precisely, all Start Events
-				   have been triggered (1.1), and for all
-				   starting Event-Based Gateways, one of the
-				   associated Events has been triggered (1.2).
-
-				   (2) There is no token remaining within the
-				   Process instance
-				*/
-				// If the node hasn't been activated, it's too early
-				if !node.activated {
-					m.response <- flow_node.NoAction{}
-				}
-				// If the node already completed, then we essentially fuse it
-				if node.completed {
-					m.response <- flow_node.CompleteAction{}
-				}
-				// To satisfy 1.1, we're observing traces to know
-				// when start events were activated. `startEventsActivated`
-				// keeps track of these.
-				// We're not taking in account remaining tokens (YET).
-				if len(node.startEventsActivated) == len(*node.FlowNode.Process.StartEvents()) {
-					if _, err := node.FlowNode.EventIngress.ConsumeProcessEvent(
-						events.MakeEndEvent(),
-					); err == nil {
-						node.completed = true
-						m.response <- flow_node.CompleteAction{}
-					}
-				}
-			default:
+		msg := <-node.runnerChannel
+		switch m := msg.(type) {
+		case incomingMessage:
+			node.activated = true
+		case nextActionMessage:
+			// If the node hasn't been activated, it's too early
+			if !node.activated {
+				m.response <- flow_node.NoAction{}
+				return
 			}
-		case trace := <-node.traces:
-			switch t := trace.(type) {
-			case tracing.FlowTrace:
-				for _, sequenceFlow := range t.SequenceFlows {
-					if source, err := sequenceFlow.Source(); err == nil {
-						switch flowNode := source.(type) {
-						case *bpmn.StartEvent:
-							node.startEventsActivated = append(node.startEventsActivated, flowNode)
-						default:
-						}
-					}
-				}
-			default:
+			// If the node already completed, then we essentially fuse it
+			if node.completed {
+				m.response <- flow_node.CompleteAction{}
+				return
 			}
+
+			if _, err := node.FlowNode.EventIngress.ConsumeProcessEvent(
+				events.MakeEndEvent(node.element),
+			); err == nil {
+				node.completed = true
+				m.response <- flow_node.CompleteAction{}
+			} else {
+				node.FlowNode.Tracer.Trace(tracing.ErrorTrace{Error: err})
+			}
+		default:
 		}
 	}
 }

--- a/pkg/flow_node/event/end_event/tests/end_event_test.go
+++ b/pkg/flow_node/event/end_event/tests/end_event_test.go
@@ -48,6 +48,7 @@ func TestEndEvent(t *testing.T) {
 				t.Logf("%#v", trace)
 			}
 		}
+		instance.Tracer.Unsubscribe(traces)
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}

--- a/pkg/flow_node/event/start_event/start_event.go
+++ b/pkg/flow_node/event/start_event/start_event.go
@@ -1,6 +1,8 @@
 package start_event
 
 import (
+	"sync"
+
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/events"
 	"bpxe.org/pkg/flow"
@@ -32,12 +34,14 @@ func NewStartEvent(process *bpmn.Process,
 	eventEgress events.ProcessEventSource,
 	tracer *tracing.Tracer,
 	flowNodeMapping *flow_node.FlowNodeMapping,
+	flowWaitGroup *sync.WaitGroup,
 ) (node *StartEvent, err error) {
 	flow_node, err := flow_node.NewFlowNode(process,
 		definitions,
 		&startEvent.FlowNode,
 		eventIngress, eventEgress,
-		tracer, flowNodeMapping)
+		tracer, flowNodeMapping,
+		flowWaitGroup)
 	if err != nil {
 		return
 	}
@@ -76,7 +80,7 @@ func (node *StartEvent) ConsumeProcessEvent(
 ) (result events.EventConsumptionResult, err error) {
 	switch ev.(type) {
 	case *events.StartEvent:
-		newFlow := flow.NewFlow(node, node.FlowNode.Tracer, node.FlowNode.FlowNodeMapping)
+		newFlow := flow.NewFlow(node, node.FlowNode.Tracer, node.FlowNode.FlowNodeMapping, node.FlowNode.FlowWaitGroup)
 		newFlow.Start()
 	default:
 	}

--- a/pkg/flow_node/event/start_event/tests/start_event_test.go
+++ b/pkg/flow_node/event/start_event/tests/start_event_test.go
@@ -48,6 +48,7 @@ func TestStartEvent(t *testing.T) {
 				t.Logf("%#v", trace)
 			}
 		}
+		instance.Tracer.Unsubscribe(traces)
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}

--- a/pkg/flow_node/flow_node.go
+++ b/pkg/flow_node/flow_node.go
@@ -1,6 +1,8 @@
 package flow_node
 
 import (
+	"sync"
+
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/errors"
 	"bpxe.org/pkg/events"
@@ -16,6 +18,7 @@ type FlowNode struct {
 	Tracer       *tracing.Tracer
 	Process      *bpmn.Process
 	*FlowNodeMapping
+	FlowWaitGroup *sync.WaitGroup
 }
 
 func sequenceFlows(process *bpmn.Process,
@@ -45,6 +48,7 @@ func NewFlowNode(process *bpmn.Process,
 	eventEgress events.ProcessEventSource,
 	tracer *tracing.Tracer,
 	flowNodeMapping *FlowNodeMapping,
+	flowWaitGroup *sync.WaitGroup,
 ) (node *FlowNode, err error) {
 	incoming, err := sequenceFlows(process, definitions, flow_node.Incomings())
 	if err != nil {
@@ -62,6 +66,7 @@ func NewFlowNode(process *bpmn.Process,
 		Tracer:          tracer,
 		Process:         process,
 		FlowNodeMapping: flowNodeMapping,
+		FlowWaitGroup:   flowWaitGroup,
 	}
 	return
 }

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -2,6 +2,7 @@ package flow_node
 
 import (
 	"encoding/xml"
+	"sync"
 	"testing"
 
 	"bpxe.org/pkg/bpmn"
@@ -25,6 +26,7 @@ func TestNewFlowNode(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 
+	var waitGroup sync.WaitGroup
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
 		if flowNode, found := sampleDoc.FindBy(bpmn.ExactId("either")); found {
 			node, err := NewFlowNode(proc.(*bpmn.Process),
@@ -33,6 +35,7 @@ func TestNewFlowNode(t *testing.T) {
 				events.VoidProcessEventConsumer{},
 				events.VoidProcessEventSource{},
 				tracing.NewTracer(), NewLockedFlowNodeMapping(),
+				&waitGroup,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, 1, len(node.Incoming))

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -1,16 +1,23 @@
 package tracing
 
+type unsubscription struct {
+	channel chan Trace
+	ok      chan bool
+}
+
 type Tracer struct {
-	traces       chan Trace
-	subscription chan chan Trace
-	subscribers  []chan Trace
+	traces         chan Trace
+	subscription   chan chan Trace
+	unsubscription chan unsubscription
+	subscribers    []chan Trace
 }
 
 func NewTracer() *Tracer {
 	tracer := Tracer{
-		subscribers:  make([]chan Trace, 0),
-		traces:       make(chan Trace),
-		subscription: make(chan chan Trace),
+		subscribers:    make([]chan Trace, 0),
+		traces:         make(chan Trace),
+		subscription:   make(chan chan Trace),
+		unsubscription: make(chan unsubscription),
 	}
 	go tracer.runner()
 	return &tracer
@@ -21,18 +28,26 @@ func (t *Tracer) runner() {
 		select {
 		case subscription := <-t.subscription:
 			t.subscribers = append(t.subscribers, subscription)
-		case trace := <-t.traces:
-			subscribers := t.subscribers[:0]
-			for _, subscriber := range t.subscribers {
-				select {
-				case subscriber <- trace:
-					// success
-					subscribers = append(subscribers, subscriber)
-				default:
-					// unsubcribe closed channel
+		case unsubscription := <-t.unsubscription:
+			pos := 0
+			for i := range t.subscribers {
+				if t.subscribers[i] == unsubscription.channel {
+					pos = i + 1
+					break
 				}
 			}
-			t.subscribers = subscribers
+			if pos > 0 {
+				end := pos
+				if pos == len(t.subscribers) {
+					pos--
+				}
+				t.subscribers = append(t.subscribers[:pos], t.subscribers[end:]...)
+				unsubscription.ok <- true
+			}
+		case trace := <-t.traces:
+			for _, subscriber := range t.subscribers {
+				subscriber <- trace
+			}
 		}
 	}
 }
@@ -41,6 +56,22 @@ func (t *Tracer) Subscribe() chan Trace {
 	channel := make(chan Trace)
 	t.subscription <- channel
 	return channel
+}
+
+func (t *Tracer) Unsubscribe(c chan Trace) {
+	okChan := make(chan bool)
+	unsub := unsubscription{channel: c, ok: okChan}
+loop:
+	for {
+		select {
+		case <-c:
+			continue loop
+		case t.unsubscription <- unsub:
+			continue loop
+		case <-okChan:
+			return
+		}
+	}
 }
 
 func (t *Tracer) Trace(trace Trace) {

--- a/pkg/tracing/traces.go
+++ b/pkg/tracing/traces.go
@@ -28,3 +28,7 @@ type ErrorTrace struct {
 }
 
 func (t ErrorTrace) TraceInterface() {}
+
+type CeaseFlowTrace struct{}
+
+func (t CeaseFlowTrace) TraceInterface() {}


### PR DESCRIPTION
Solution: track start activation and flow completion using wait groups

There's now an additional goroutine started alongside the instance that
first waits for all start events to be activated (sequence flows
originating from them) and then for all flows to end, sending out a
newly introduced `CeaseFlowTrace` trace to indicate what happened.

`instance.ProcessInstance` got `WaitUntilComplete` method to expose the
result of the aforementioned tracking.

`events.EndEvent` event also got a reference to its element to allow
detecting *which* `EndEvent` has been activated.

Previously, `EndEvent` flow node was observing `StartEvent` activations
to avoid completion before they all have been activated. I believe this
is wrong and a particular `EndEvent` should not care about this as the
process might still be incomplete. That logic was coming from the fact
that `events.EndEvent` event had no payload that would indicate which
`EndEvent` has been activated.

I also had to improve `tracing.Tracer` a little bit and add
unsubscription functionality to it to ensure that we can avoid blocking
on sending traces to subscribers that are no longer interested in
traces. The subscribers MUST unsubscribe themselves, otherwise they'll
block the tracer if they don't consume traces. This is still not
perfect, but I guess it'll do for now.