### PR TITLE
Problem: intermittently hanging test in pkg/flow/tests

### DIFF
--- a/pkg/process/instance.go
+++ b/pkg/process/instance.go
@@ -90,6 +90,7 @@ func (instance *ProcessInstance) RegisterProcessEventConsumer(ev events.ProcessE
 func (instance *ProcessInstance) Run() (err error) {
 	lockChan := make(chan bool)
 	go func() {
+		traces := instance.Tracer.Subscribe()
 		instance.complete.Lock()
 		lockChan <- true
 		/* 13.4.6 End Events:
@@ -108,7 +109,6 @@ func (instance *ProcessInstance) Run() (err error) {
 		Process instance
 		*/
 		startEventsActivated := make([]*bpmn.StartEvent, 0)
-		traces := instance.Tracer.Subscribe()
 
 		// So, at first, we wait for (1.1) to occur
 		// [(1.2) will be addded when we actually support them]


### PR DESCRIPTION
I've noticed that pkg/flow/tests hangs regularly.

Solution: move flow cease detector's subscription earlier

The problem was that by the time flow cease detector's goroutine was
subscribing, it was too late it wasn't getting messages as the testing
thread already ran `instance.Run()` and therefore detector wasn't
getting messages it was hoping for.