### PR TITLE
Problem: risk of unlicensed dependencies

### DIFF
--- a/test/license_test.go
+++ b/test/license_test.go
@@ -48,6 +48,14 @@ func TestDependencyLicenses(t *testing.T) {
 			assert.Nil(t, err)
 			licenses, err := licensedb.Detect(f)
 			assert.Nil(t, err)
+			if len(licenses) == 0 {
+				alerts <- dependencyAlert{
+					dependency: dependency,
+					license:    "none",
+					confidence: 1,
+				}
+				return
+			}
 			for license := range licenses {
 				if strings.Contains(license, "GPL") {
 					alerts <- dependencyAlert{
@@ -56,6 +64,7 @@ func TestDependencyLicenses(t *testing.T) {
 						confidence: licenses[license].Confidence,
 					}
 				}
+				return
 			}
 		}(dependency)
 


### PR DESCRIPTION
These dependencies can be effectively violations if there's no license
grant.

Solution: check for dependencies with no licenses detected