### PR TITLE
Problem: relying on snapshot of github.com/muyo/sno

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,7 @@ require (
 	github.com/go-enry/go-license-detector/v4 v4.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
-	// Latest sno doesn't exhibit SSE2 bug (https://github.com/muyo/sno/issues/3)
-	github.com/muyo/sno v1.1.1-0.20200406142550-e5d36f06b5d6
+	github.com/muyo/sno v1.2.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb h1:bsjNADsjHq0g
 github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/muyo/sno v1.1.1-0.20200406142550-e5d36f06b5d6 h1:Hn9jPTavsRibTYH27W5CAEwxDsSM6tDUlYB2bPEP89Q=
 github.com/muyo/sno v1.1.1-0.20200406142550-e5d36f06b5d6/go.mod h1:Hjr5WzLleYD7bJYvQGo5UK7hpE2kSvMbihc0bMWF2bU=
+github.com/muyo/sno v1.2.0 h1:/J+vDR2g9A05b+BAOi/YiPTtPt0CuQPMcxcgnMZFT6I=
+github.com/muyo/sno v1.2.0/go.mod h1:Hjr5WzLleYD7bJYvQGo5UK7hpE2kSvMbihc0bMWF2bU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/neurosnap/sentences v1.0.6 h1:iBVUivNtlwGkYsJblWV8GGVFmXzZzak907Ci8aA0VTE=
 github.com/neurosnap/sentences v1.0.6/go.mod h1:pg1IapvYpWCJJm/Etxeh0+gtMf1rI1STY9S7eUCPbDc=

--- a/vendor/github.com/muyo/sno/generator.go
+++ b/vendor/github.com/muyo/sno/generator.go
@@ -120,7 +120,7 @@ retry:
 	)
 
 	// Fastest branch if we're still within the most recent time unit.
-	if wallHi == wallNow {
+	if wallNow == wallHi {
 		seq := atomic.AddUint32(&g.seq, 1)
 
 		if g.seqMax >= seq {
@@ -199,7 +199,7 @@ retry:
 
 		g.regression.Unlock()
 
-		return id
+		return
 	}
 
 	// Branch for all routines that are in an "unsafe" past (e.g. multiple time regressions happened

--- a/vendor/github.com/muyo/sno/internal/cpu_amd64.s
+++ b/vendor/github.com/muyo/sno/internal/cpu_amd64.s
@@ -3,7 +3,7 @@
 
 // func cpuidReal(op uint32) (eax, ebx, ecx, edx uint32)
 TEXT ·cpuidReal(SB), NOSPLIT, $0-24
-	MOVL op+0(FP), AX
+    MOVL op+0(FP), AX
     XORQ CX, CX
     CPUID
     MOVL AX, eax+8(FP)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,7 +139,7 @@ github.com/mitchellh/go-homedir
 github.com/mitchellh/mapstructure
 # github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb
 github.com/montanaflynn/stats
-# github.com/muyo/sno v1.1.1-0.20200406142550-e5d36f06b5d6
+# github.com/muyo/sno v1.2.0
 ## explicit
 github.com/muyo/sno
 github.com/muyo/sno/internal


### PR DESCRIPTION
Solution: upgrade to 1.2.0

Following the discussion in https://github.com/muyo/sno/issues/3,
@alcore released 1.2.0