### PR TITLE
Problem: long, redundant type names

### DIFF
--- a/pkg/event/consumer_test.go
+++ b/pkg/event/consumer_test.go
@@ -10,8 +10,8 @@ import (
 
 type erroringConsumer struct{}
 
-func (c erroringConsumer) ConsumeProcessEvent(ProcessEvent) (EventConsumptionResult, error) {
-	return EventConsumptionError, errors.New("some error")
+func (c erroringConsumer) ConsumeProcessEvent(ProcessEvent) (ConsumptionResult, error) {
+	return ConsumptionError, errors.New("some error")
 }
 
 func TestForwardProcessEvent(t *testing.T) {
@@ -21,24 +21,24 @@ func TestForwardProcessEvent(t *testing.T) {
 		VoidProcessEventConsumer{}}
 	allErroringConsumers := []ProcessEventConsumer{erroringConsumer{},
 		erroringConsumer{}}
-	var result EventConsumptionResult
+	var result ConsumptionResult
 	var multiErr *multierror.Error
 	var err error
 	var ok bool
 
 	result, err = ForwardProcessEvent(MakeStartEvent(), &someErroringConsumers)
-	assert.Equal(t, EventPartiallyConsumed, result)
+	assert.Equal(t, PartiallyConsumed, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)
 	assert.True(t, ok)
 	assert.Equal(t, 1, multiErr.Len())
 
 	result, err = ForwardProcessEvent(MakeStartEvent(), &noErroringConsumers)
-	assert.Equal(t, EventConsumed, result)
+	assert.Equal(t, Consumed, result)
 	assert.Nil(t, err)
 
 	result, err = ForwardProcessEvent(MakeStartEvent(), &allErroringConsumers)
-	assert.Equal(t, EventConsumptionError, result)
+	assert.Equal(t, ConsumptionError, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)
 	assert.True(t, ok)

--- a/pkg/flow_node/event/intermediate_catch_event/intermediate_catch_event.go
+++ b/pkg/flow_node/event/intermediate_catch_event/intermediate_catch_event.go
@@ -131,9 +131,9 @@ loop:
 
 func (node *IntermediateCatchEvent) ConsumeProcessEvent(
 	ev event.ProcessEvent,
-) (result event.EventConsumptionResult, err error) {
+) (result event.ConsumptionResult, err error) {
 	node.runnerChannel <- processEventMessage{event: ev}
-	result = event.EventConsumed
+	result = event.Consumed
 	return
 }
 

--- a/pkg/flow_node/event/start_event/start_event.go
+++ b/pkg/flow_node/event/start_event/start_event.go
@@ -81,7 +81,7 @@ func (node *StartEvent) runner() {
 
 func (node *StartEvent) ConsumeProcessEvent(
 	ev event.ProcessEvent,
-) (result event.EventConsumptionResult, err error) {
+) (result event.ConsumptionResult, err error) {
 	switch ev.(type) {
 	case *event.StartEvent:
 		newFlow := flow.NewFlow(node.FlowNode.Definitions, node, node.FlowNode.Tracer,
@@ -89,7 +89,7 @@ func (node *StartEvent) ConsumeProcessEvent(
 		newFlow.Start()
 	default:
 	}
-	result = event.EventConsumed
+	result = event.Consumed
 	return
 }
 

--- a/pkg/process/instance.go
+++ b/pkg/process/instance.go
@@ -19,7 +19,7 @@ import (
 	"bpxe.org/pkg/tracing"
 )
 
-type ProcessInstance struct {
+type Instance struct {
 	process         *Process
 	eventConsumers  []event.ProcessEventConsumer
 	Tracer          *tracing.Tracer
@@ -29,7 +29,7 @@ type ProcessInstance struct {
 	idGenerator     id.IdGenerator
 }
 
-func NewProcessInstance(process *Process) (instance *ProcessInstance, err error) {
+func NewInstance(process *Process) (instance *Instance, err error) {
 	eventConsumers := make([]event.ProcessEventConsumer, 0)
 	tracer := tracing.NewTracer()
 	var idGenerator id.IdGenerator
@@ -37,7 +37,7 @@ func NewProcessInstance(process *Process) (instance *ProcessInstance, err error)
 	if err != nil {
 		return
 	}
-	instance = &ProcessInstance{
+	instance = &Instance{
 		process:         process,
 		eventConsumers:  eventConsumers,
 		Tracer:          tracer,
@@ -150,17 +150,17 @@ func NewProcessInstance(process *Process) (instance *ProcessInstance, err error)
 	return
 }
 
-func (instance *ProcessInstance) ConsumeProcessEvent(ev event.ProcessEvent) (result event.EventConsumptionResult, err error) {
+func (instance *Instance) ConsumeProcessEvent(ev event.ProcessEvent) (result event.ConsumptionResult, err error) {
 	result, err = event.ForwardProcessEvent(ev, &instance.eventConsumers)
 	return
 }
 
-func (instance *ProcessInstance) RegisterProcessEventConsumer(ev event.ProcessEventConsumer) (err error) {
+func (instance *Instance) RegisterProcessEventConsumer(ev event.ProcessEventConsumer) (err error) {
 	instance.eventConsumers = append(instance.eventConsumers, ev)
 	return
 }
 
-func (instance *ProcessInstance) Run() (err error) {
+func (instance *Instance) Run() (err error) {
 	lockChan := make(chan bool)
 	go func() {
 		traces := instance.Tracer.Subscribe()
@@ -230,7 +230,7 @@ func (instance *ProcessInstance) Run() (err error) {
 
 // Waits until the instance is complete. Returns true if the instance was complete,
 // false if the context signalled `Done`
-func (instance *ProcessInstance) WaitUntilComplete(ctx context.Context) (complete bool) {
+func (instance *Instance) WaitUntilComplete(ctx context.Context) (complete bool) {
 	signal := make(chan bool)
 	go func() {
 		instance.complete.Lock()

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -10,7 +10,7 @@ type Process struct {
 	Element     *bpmn.Process
 	Definitions *bpmn.Definitions
 	id.IdGeneratorBuilder
-	instances            []*ProcessInstance
+	instances            []*Instance
 	eventInstanceBuilder event.InstanceBuilder
 }
 
@@ -23,7 +23,7 @@ func MakeProcess(element *bpmn.Process, definitions *bpmn.Definitions, idGenerat
 		Element:            element,
 		Definitions:        definitions,
 		IdGeneratorBuilder: idGeneratorBuilder,
-		instances:          make([]*ProcessInstance, 0),
+		instances:          make([]*Instance, 0),
 	}
 }
 
@@ -37,8 +37,8 @@ func NewProcessWithIdGeneratorBuilder(element *bpmn.Process, definitions *bpmn.D
 	return &process
 }
 
-func (process *Process) Instantiate() (instance *ProcessInstance, err error) {
-	instance, err = NewProcessInstance(process)
+func (process *Process) Instantiate() (instance *Instance, err error) {
+	instance, err = NewInstance(process)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In certain places, type names are rather long and redundant. This is called
"name stuttering" and is a practice that is advised against in Effective Go because
these names are just making the code noiser.

Solution: rename affected types

I am not 100% sure if I should also rename specific flow node names from their
self-descriptive names to something like Node, so I left that out for now.