### PR TITLE
Problem: flow termination mechanics

### DIFF
--- a/pkg/flow_node/action.go
+++ b/pkg/flow_node/action.go
@@ -1,7 +1,7 @@
 package flow_node
 
 import (
-	"bpxe.org/pkg/id"
+	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/sequence_flow"
 )
 
@@ -19,8 +19,8 @@ type ProbeAction struct {
 
 func (action ProbeAction) action() {}
 
-type ActionTransformer func(id.Id, Action) Action
-type Terminate chan func(id id.Id) bool
+type ActionTransformer func(sequenceFlowId bpmn.IdRef, action Action) Action
+type Terminate func(sequenceFlowId bpmn.IdRef) chan bool
 
 type FlowAction struct {
 	SequenceFlows []*sequence_flow.SequenceFlow

--- a/pkg/flow_node/activity/task/task.go
+++ b/pkg/flow_node/activity/task/task.go
@@ -80,10 +80,10 @@ func (node *Task) runner() {
 	}
 }
 
-func (node *Task) NextAction(id.Id) flow_node.Action {
+func (node *Task) NextAction(id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response}
-	return <-response
+	return response
 }
 
 func (node *Task) Incoming(index int) {

--- a/pkg/flow_node/event/end_event/end_event.go
+++ b/pkg/flow_node/event/end_event/end_event.go
@@ -100,10 +100,10 @@ func (node *EndEvent) runner() {
 	}
 }
 
-func (node *EndEvent) NextAction(id.Id) flow_node.Action {
+func (node *EndEvent) NextAction(id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response}
-	return <-response
+	return response
 }
 
 func (node *EndEvent) Incoming(index int) {

--- a/pkg/flow_node/event/intermediate_catch_event/intermediate_catch_event.go
+++ b/pkg/flow_node/event/intermediate_catch_event/intermediate_catch_event.go
@@ -137,10 +137,10 @@ func (node *IntermediateCatchEvent) ConsumeProcessEvent(
 	return
 }
 
-func (node *IntermediateCatchEvent) NextAction(id.Id) flow_node.Action {
+func (node *IntermediateCatchEvent) NextAction(id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response}
-	return <-response
+	return response
 }
 
 func (node *IntermediateCatchEvent) Incoming(index int) {

--- a/pkg/flow_node/event/start_event/start_event.go
+++ b/pkg/flow_node/event/start_event/start_event.go
@@ -93,10 +93,10 @@ func (node *StartEvent) ConsumeProcessEvent(
 	return
 }
 
-func (node *StartEvent) NextAction(id.Id) flow_node.Action {
+func (node *StartEvent) NextAction(id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response}
-	return <-response
+	return response
 }
 
 func (node *StartEvent) Incoming(int) {

--- a/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
@@ -201,10 +201,10 @@ func (node *ExclusiveGateway) runner() {
 	}
 }
 
-func (node *ExclusiveGateway) NextAction(flowId id.Id) flow_node.Action {
+func (node *ExclusiveGateway) NextAction(flowId id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response, flowId: flowId}
-	return <-response
+	return response
 }
 
 func (node *ExclusiveGateway) Incoming(index int) {

--- a/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
+++ b/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
@@ -127,10 +127,10 @@ loop:
 	}
 }
 
-func (node *ParallelGateway) NextAction(flowId id.Id) flow_node.Action {
+func (node *ParallelGateway) NextAction(flowId id.Id) chan flow_node.Action {
 	response := make(chan flow_node.Action)
 	node.runnerChannel <- nextActionMessage{response: response, flowId: flowId}
-	return <-response
+	return response
 }
 
 func (node *ParallelGateway) Incoming(index int) {

--- a/pkg/flow_node/outgoing.go
+++ b/pkg/flow_node/outgoing.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Outgoing interface {
-	NextAction(flowId id.Id) Action
+	NextAction(flowId id.Id) chan Action
 }
 
 func AllSequenceFlows(


### PR DESCRIPTION
As I mentioned before, I don't particularly like the mechanism for
flow termination used for event based gateway. It's wasteful and brittle:

* It depends on parallel flow correctly consuming only one value from the termination channel
* It forces every flow to call flow node's `NextAction` in a channel to
  select on it and the termination channel

Solution: reorganize the mechanics

Firstly, NextAction() now returns `chan Action` instead of `Action`. All
existing implementations rely on reading from a result channel internally anyway,
so this seems to be rather counterproductive to start a goroutine to just
re-send the value (goroutines have overhead).

Secondly, termination channel has been split into multiple termination channels, one per sequence flow so only relevant ones will be notified.