### PR TITLE
Problem: intermediate_catch_event_test occasionally times out

### DIFF
--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -60,8 +60,20 @@ func (t *Tracer) runner() {
 	}
 }
 
+// Subscribe creates a new unbuffered channel and subscribes it to
+// traces from the Tracer
+//
+// Note that this channel should be continuously read from until unsubscribed
+// from, otherwise, the Tracer will block.
 func (t *Tracer) Subscribe() chan Trace {
-	channel := make(chan Trace)
+	return t.SubscribeChannel(make(chan Trace))
+}
+
+// SubscribeChannel subscribes a channel to traces from the Tracer
+//
+// Note that this channel should be continuously read from (modulo
+// buffering), otherwise, the Tracer will block.
+func (t *Tracer) SubscribeChannel(channel chan Trace) chan Trace {
 	okChan := make(chan bool)
 	sub := subscription{channel: channel, ok: okChan}
 	t.subscription <- sub


### PR DESCRIPTION
Solution: make trace channel buffered

This way it doesn't lock up and time out. This required amending
`pkg/tracing/Tracer` API with `SubscribeChannel` to support this case.

Also, the last goroutine in the test function unsubscribes upon return.

While it does seem to solve the current problem, it still leaves me somewhat uneasy
about the design of Tracer. It's still prone to blocking if used improperly
(trace channels not being read from actively enough or not unsubscribed from
when no longer needed)

**More importantly**, this PR fixes a race condition:

There was a problem in how IntermediateCatchEvent was handling Incoming &
NextAction. It was activated upon Incoming but only added pending Action
channels upon getting NextAction. If a matching event is received between
these two steps, they will be successfully processed but there will be no
Action channels to report to. Effectively, these matched events would have
no observable effects on the flow.
    
Similar change is made to EventBasedGateway. EventBasedGateway can be used
to instantiate a process (not supported by BPXE just yet) and therefore it
won't have an Incoming in this case.
