### PR TITLE
Problem: intermittently timing out test

### DIFF
--- a/pkg/flow_node/activity/harness.go
+++ b/pkg/flow_node/activity/harness.go
@@ -106,7 +106,7 @@ func NewHarness(process *bpmn.Process,
 	node = &Harness{
 		FlowNode:                  *flowNode,
 		element:                   element,
-		runnerChannel:             make(chan message),
+		runnerChannel:             make(chan message, len(flowNode.Incoming)*2+1),
 		activity:                  activity,
 		activeBoundary:            activity.ActiveBoundary(),
 		idGenerator:               idGenerator,

--- a/pkg/flow_node/activity/task/task.go
+++ b/pkg/flow_node/activity/task/task.go
@@ -77,7 +77,7 @@ func NewTask(startEvent *bpmn.Task) activity.Constructor {
 		taskNode := &Task{
 			FlowNode:       *flowNode,
 			element:        startEvent,
-			runnerChannel:  make(chan message),
+			runnerChannel:  make(chan message, len(flowNode.Incoming)*2+1),
 			activeBoundary: make(chan bool),
 			ctx:            ctx,
 			cancel:         cancel,

--- a/pkg/flow_node/event/catch_event/catch_event.go
+++ b/pkg/flow_node/event/catch_event/catch_event.go
@@ -59,7 +59,7 @@ func NewCatchEvent(process *bpmn.Process, definitions *bpmn.Definitions,
 	node = &CatchEvent{
 		FlowNode:        *flowNode,
 		element:         intermediateCatchEvent,
-		runnerChannel:   make(chan message),
+		runnerChannel:   make(chan message, len(flowNode.Incoming)*2+1),
 		activated:       false,
 		awaitingActions: make([]chan flow_node.Action, 0),
 		eventInstances:  eventInstances,

--- a/pkg/flow_node/event/end_event/end_event.go
+++ b/pkg/flow_node/event/end_event/end_event.go
@@ -62,7 +62,7 @@ func NewEndEvent(process *bpmn.Process,
 		activated:            false,
 		completed:            false,
 		eventConsumer:        eventIngress,
-		runnerChannel:        make(chan message),
+		runnerChannel:        make(chan message, len(flowNode.Incoming)*2+1),
 		startEventsActivated: make([]*bpmn.StartEvent, 0),
 	}
 	go node.runner()

--- a/pkg/flow_node/event/start_event/start_event.go
+++ b/pkg/flow_node/event/start_event/start_event.go
@@ -52,7 +52,7 @@ func NewStartEvent(process *bpmn.Process,
 	node = &StartEvent{
 		FlowNode:      *flowNode,
 		element:       startEvent,
-		runnerChannel: make(chan message),
+		runnerChannel: make(chan message, len(flowNode.Incoming)*2+1),
 		activated:     false,
 		idGenerator:   idGenerator,
 	}

--- a/pkg/flow_node/gateway/event_based_gateway/event_based_gateway.go
+++ b/pkg/flow_node/gateway/event_based_gateway/event_based_gateway.go
@@ -47,7 +47,7 @@ func NewEventBasedGateway(process *bpmn.Process, definitions *bpmn.Definitions, 
 	node = &EventBasedGateway{
 		FlowNode:      *flowNode,
 		element:       eventBasedGateway,
-		runnerChannel: make(chan message),
+		runnerChannel: make(chan message, len(flowNode.Incoming)*2+1),
 		activated:     false,
 	}
 	go node.runner()

--- a/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
@@ -108,7 +108,7 @@ func NewExclusiveGateway(process *bpmn.Process,
 	node = &ExclusiveGateway{
 		FlowNode:                *flowNode,
 		element:                 exclusiveGateway,
-		runnerChannel:           make(chan message),
+		runnerChannel:           make(chan message, len(flowNode.Incoming)*2+1),
 		nonDefaultSequenceFlows: nonDefaultSequenceFlows,
 		defaultSequenceFlow:     defaultSequenceFlow,
 		probing:                 make(map[id.Id]*chan flow_node.Action),

--- a/pkg/flow_node/gateway/inclusive_gateway/inclusive_gateway.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/inclusive_gateway.go
@@ -119,7 +119,7 @@ func NewInclusiveGateway(process *bpmn.Process,
 	node = &InclusiveGateway{
 		FlowNode:                *flowNode,
 		element:                 inclusiveGateway,
-		runnerChannel:           make(chan message),
+		runnerChannel:           make(chan message, len(flowNode.Incoming)*2+1),
 		nonDefaultSequenceFlows: nonDefaultSequenceFlows,
 		defaultSequenceFlow:     defaultSequenceFlow,
 		flowTracker:             newFlowTracker(tracer),

--- a/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
+++ b/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
@@ -59,7 +59,7 @@ func NewParallelGateway(process *bpmn.Process,
 	node = &ParallelGateway{
 		FlowNode:              *flowNode,
 		element:               parallelGateway,
-		runnerChannel:         make(chan message),
+		runnerChannel:         make(chan message, len(flowNode.Incoming)*2+1),
 		reportedIncomingFlows: make([]int, 0),
 		awaitingActions:       make([]chan flow_node.Action, 0),
 		noOfIncomingFlows:     len(flowNode.Incoming),


### PR DESCRIPTION
Exclusive gateway's TestExclusiveGatewayIncompleteJoin
is intermittently (but fairly regularly) hangs and times out

Solution: increase runner channel capacity in flow nodes

Currently set at NumberOfIncomingSequenceFlows * 2 + 1, to account
for extra messages that might be required and for cases where there
are no incoming flows (such as boundary events).

I currently see no reason to make every call to flow nodes fully
synchronous (this does tend to lock goroutines up).

This eliminates the occasional test timeout mentioned above but
tests still occassionally result in a timeout, further investigation is
required.