### PR TITLE
Problem: source code files don't have license references

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - goheader
     - errorlint
     - gocritic
     - godox
@@ -7,3 +8,10 @@ linters:
     - gosec
     - misspell
     - nilerr
+
+linters-settings:
+  goheader:
+    template-path: ".header.txt"
+    values:
+      const:
+        Owner: "Aree Enterprises, Inc. and Contributors"

--- a/.header.txt
+++ b/.header.txt
@@ -1,0 +1,7 @@
+Copyright (c) {{Year}} {{Owner}}
+Use of this software is governed by the Business Source License
+included in the file LICENSE
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0, included in the file
+licenses/LICENSE-Apache-2.0

--- a/.license.yml
+++ b/.license.yml
@@ -1,0 +1,11 @@
+header: |
+ // Copyright (c) {{YEAR}} Aree Enterprises, Inc. and Contributors
+ // Use of this software is governed by the Business Source License
+ // included in the file LICENSE
+ // As of the Change Date specified in that file, in accordance with
+ // the Business Source License, use of this software will be governed
+ // by the Apache License, Version 2.0, included in the file
+ // licenses/LICENSE-Apache-2.0
+exclude:
+  names:
+    - "vendor"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ all: check ## Build bpxe
 test: check ## Run tests
 	go test ./...
 
+headers:
+	@go-license --config=.license.yml $(wildcard **/**.go **/**/**.go **/**/**/**.go **/**/**/**/**.go **/**/**/**/**/**.go)
+
 generate: ## Generate source files (only needed if schema changes)
 	go generate ./...
 	go fmt ./...

--- a/cmd/bpxe/cmd/execute.go
+++ b/cmd/bpxe/cmd/execute.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/bpxe/cmd/root.go
+++ b/cmd/bpxe/cmd/root.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/bpxe/main.go
+++ b/cmd/bpxe/main.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package main
 
 import "bpxe.org/cmd/bpxe/cmd"

--- a/pkg/bpmn/bpmn_parser_test.go
+++ b/pkg/bpmn/bpmn_parser_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package bpmn
 
 import (

--- a/pkg/bpmn/package.go
+++ b/pkg/bpmn/package.go
@@ -1,2 +1,10 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Package bpmn encapsulates BPMN document management
 package bpmn

--- a/pkg/bpmn/schema.go
+++ b/pkg/bpmn/schema.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package bpmn
 
 import (

--- a/pkg/bpmn/schema_generated.go
+++ b/pkg/bpmn/schema_generated.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package bpmn
 
 // This file is generated from BPMN 2.0 schema using `make generate`

--- a/pkg/bpmn/schema_generated_test.go
+++ b/pkg/bpmn/schema_generated_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // This content is generated from BPMN 2.0 schema using `make generate`
 // DO NOT EDIT
 package bpmn

--- a/pkg/bpmn/schema_test.go
+++ b/pkg/bpmn/schema_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package bpmn
 
 import (

--- a/pkg/bpmn/testdata_test.go
+++ b/pkg/bpmn/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package bpmn
 
 import "embed"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package errors
 
 import "fmt"

--- a/pkg/errors/package.go
+++ b/pkg/errors/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package errors

--- a/pkg/event/consumer.go
+++ b/pkg/event/consumer.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event
 
 import (

--- a/pkg/event/consumer_test.go
+++ b/pkg/event/consumer_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event
 
 import (

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event
 
 import (

--- a/pkg/event/instance.go
+++ b/pkg/event/instance.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event
 
 import (

--- a/pkg/event/package.go
+++ b/pkg/event/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event

--- a/pkg/event/source.go
+++ b/pkg/event/source.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event
 
 type ProcessEventSource interface {

--- a/pkg/expression/engine.go
+++ b/pkg/expression/engine.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 type Compiler interface {

--- a/pkg/expression/engines.go
+++ b/pkg/expression/engines.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 var enginesMap = map[string]func() Engine{

--- a/pkg/expression/expr.go
+++ b/pkg/expression/expr.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 import (

--- a/pkg/expression/expr_test.go
+++ b/pkg/expression/expr_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 import (

--- a/pkg/expression/package.go
+++ b/pkg/expression/package.go
@@ -1,2 +1,10 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Expression languages and their compilation/execution engines
 package expression

--- a/pkg/expression/xpath.go
+++ b/pkg/expression/xpath.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 import (

--- a/pkg/expression/xpath_test.go
+++ b/pkg/expression/xpath_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package expression
 
 import (

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow
 
 import (

--- a/pkg/flow/flow_interface/flow_interface.go
+++ b/pkg/flow/flow_interface/flow_interface.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_interface
 
 import (

--- a/pkg/flow/flow_interface/package.go
+++ b/pkg/flow/flow_interface/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_interface

--- a/pkg/flow/package.go
+++ b/pkg/flow/package.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Flow is a process that connects flow nodes, activating
 // them and carrying out their actions forward
 package flow

--- a/pkg/flow/snapshot.go
+++ b/pkg/flow/snapshot.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow
 
 import (

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow/tests/testdata_test.go
+++ b/pkg/flow/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow/traces.go
+++ b/pkg/flow/traces.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow
 
 import (

--- a/pkg/flow_node/action.go
+++ b/pkg/flow_node/action.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/activity/harness.go
+++ b/pkg/flow_node/activity/harness.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package activity
 
 import (

--- a/pkg/flow_node/activity/interface.go
+++ b/pkg/flow_node/activity/interface.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package activity
 
 import (

--- a/pkg/flow_node/activity/package.go
+++ b/pkg/flow_node/activity/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package activity

--- a/pkg/flow_node/activity/task/package.go
+++ b/pkg/flow_node/activity/task/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package task

--- a/pkg/flow_node/activity/task/task.go
+++ b/pkg/flow_node/activity/task/task.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package task
 
 import (

--- a/pkg/flow_node/activity/task/tests/task_test.go
+++ b/pkg/flow_node/activity/task/tests/task_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/activity/task/tests/testdata_test.go
+++ b/pkg/flow_node/activity/task/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/activity/tests/boundary_test.go
+++ b/pkg/flow_node/activity/tests/boundary_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/activity/tests/package.go
+++ b/pkg/flow_node/activity/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/activity/tests/testdata_test.go
+++ b/pkg/flow_node/activity/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/activity/traces.go
+++ b/pkg/flow_node/activity/traces.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package activity
 
 import (

--- a/pkg/flow_node/event/catch_event/catch_event.go
+++ b/pkg/flow_node/event/catch_event/catch_event.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package catch_event
 
 import (

--- a/pkg/flow_node/event/catch_event/package.go
+++ b/pkg/flow_node/event/catch_event/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package catch_event

--- a/pkg/flow_node/event/catch_event/tests/catch_event_test.go
+++ b/pkg/flow_node/event/catch_event/tests/catch_event_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/event/catch_event/tests/package.go
+++ b/pkg/flow_node/event/catch_event/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/event/catch_event/tests/testdata_test.go
+++ b/pkg/flow_node/event/catch_event/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/event/catch_event/traces.go
+++ b/pkg/flow_node/event/catch_event/traces.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package catch_event
 
 import (

--- a/pkg/flow_node/event/end_event/end_event.go
+++ b/pkg/flow_node/event/end_event/end_event.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package end_event
 
 import (

--- a/pkg/flow_node/event/end_event/end_event_test.go
+++ b/pkg/flow_node/event/end_event/end_event_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package end_event
 
 import (

--- a/pkg/flow_node/event/end_event/package.go
+++ b/pkg/flow_node/event/end_event/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package end_event

--- a/pkg/flow_node/event/end_event/tests/end_event_test.go
+++ b/pkg/flow_node/event/end_event/tests/end_event_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/event/end_event/tests/package.go
+++ b/pkg/flow_node/event/end_event/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/event/end_event/tests/testdata_test.go
+++ b/pkg/flow_node/event/end_event/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/event/start_event/package.go
+++ b/pkg/flow_node/event/start_event/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package start_event

--- a/pkg/flow_node/event/start_event/start_event.go
+++ b/pkg/flow_node/event/start_event/start_event.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package start_event
 
 import (

--- a/pkg/flow_node/event/start_event/start_event_test.go
+++ b/pkg/flow_node/event/start_event/start_event_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package start_event
 
 import (

--- a/pkg/flow_node/event/start_event/tests/package.go
+++ b/pkg/flow_node/event/start_event/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/event/start_event/tests/start_event_test.go
+++ b/pkg/flow_node/event/start_event/tests/start_event_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/event/start_event/tests/testdata_test.go
+++ b/pkg/flow_node/event/start_event/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/flow_node.go
+++ b/pkg/flow_node/flow_node.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/gateway/event_based_gateway/event_based_gateway.go
+++ b/pkg/flow_node/gateway/event_based_gateway/event_based_gateway.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event_based_gateway
 
 import (

--- a/pkg/flow_node/gateway/event_based_gateway/package.go
+++ b/pkg/flow_node/gateway/event_based_gateway/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event_based_gateway

--- a/pkg/flow_node/gateway/event_based_gateway/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based_gateway/tests/event_based_gateway_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/gateway/event_based_gateway/tests/package.go
+++ b/pkg/flow_node/gateway/event_based_gateway/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/gateway/event_based_gateway/tests/testdata_test.go
+++ b/pkg/flow_node/gateway/event_based_gateway/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/gateway/event_based_gateway/traces.go
+++ b/pkg/flow_node/gateway/event_based_gateway/traces.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package event_based_gateway
 
 import (

--- a/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/exclusive_gateway.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package exclusive_gateway
 
 import (

--- a/pkg/flow_node/gateway/exclusive_gateway/package.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/package.go
@@ -1,2 +1,10 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Exclusive Gateway (10.5.2)
 package exclusive_gateway

--- a/pkg/flow_node/gateway/exclusive_gateway/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/tests/exclusive_gateway_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/gateway/exclusive_gateway/tests/package.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/gateway/exclusive_gateway/tests/testdata_test.go
+++ b/pkg/flow_node/gateway/exclusive_gateway/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/gateway/flows.go
+++ b/pkg/flow_node/gateway/flows.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package gateway
 
 import (

--- a/pkg/flow_node/gateway/inclusive_gateway/flow_tracker.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/flow_tracker.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package inclusive_gateway
 
 import (

--- a/pkg/flow_node/gateway/inclusive_gateway/inclusive_gateway.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/inclusive_gateway.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package inclusive_gateway
 
 import (

--- a/pkg/flow_node/gateway/inclusive_gateway/package.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package inclusive_gateway

--- a/pkg/flow_node/gateway/inclusive_gateway/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/tests/inclusive_gateway_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/gateway/inclusive_gateway/tests/package.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/tests/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests

--- a/pkg/flow_node/gateway/inclusive_gateway/tests/testdata_test.go
+++ b/pkg/flow_node/gateway/inclusive_gateway/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/gateway/parallel_gateway/package.go
+++ b/pkg/flow_node/gateway/parallel_gateway/package.go
@@ -1,2 +1,10 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Parallel Gateway (10.5.4)
 package parallel_gateway

--- a/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
+++ b/pkg/flow_node/gateway/parallel_gateway/parallel_gateway.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package parallel_gateway
 
 import (

--- a/pkg/flow_node/gateway/parallel_gateway/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel_gateway/tests/parallel_gateway_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import (

--- a/pkg/flow_node/gateway/parallel_gateway/tests/testdata_test.go
+++ b/pkg/flow_node/gateway/parallel_gateway/tests/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tests
 
 import "embed"

--- a/pkg/flow_node/incoming.go
+++ b/pkg/flow_node/incoming.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 type Incoming interface {

--- a/pkg/flow_node/interface.go
+++ b/pkg/flow_node/interface.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/map.go
+++ b/pkg/flow_node/map.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/outgoing.go
+++ b/pkg/flow_node/outgoing.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import (

--- a/pkg/flow_node/package.go
+++ b/pkg/flow_node/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node

--- a/pkg/flow_node/testdata_test.go
+++ b/pkg/flow_node/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package flow_node
 
 import "embed"

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package id
 
 import (

--- a/pkg/id/package.go
+++ b/pkg/id/package.go
@@ -1,2 +1,10 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Unique ID generation
 package id

--- a/pkg/id/sno.go
+++ b/pkg/id/sno.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package id
 
 import (

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package model
 
 import (

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package model
 
 import (

--- a/pkg/model/package.go
+++ b/pkg/model/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package model

--- a/pkg/model/testdata_test.go
+++ b/pkg/model/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package model
 
 import "embed"

--- a/pkg/process/gops.go
+++ b/pkg/process/gops.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // +build gops
 
 package process

--- a/pkg/process/instance.go
+++ b/pkg/process/instance.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package process
 
 import (

--- a/pkg/process/package.go
+++ b/pkg/process/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package process

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package process
 
 import (

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package process
 
 import (

--- a/pkg/process/testdata_test.go
+++ b/pkg/process/testdata_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package process
 
 import "embed"

--- a/pkg/sequence_flow/package.go
+++ b/pkg/sequence_flow/package.go
@@ -1,1 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package sequence_flow

--- a/pkg/sequence_flow/sequence_flow.go
+++ b/pkg/sequence_flow/sequence_flow.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package sequence_flow
 
 import (

--- a/pkg/tracing/package.go
+++ b/pkg/tracing/package.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 // Tracing is a capability to get an ordered stream of
 // structured records of what has happened.
 //

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tracing
 
 type subscription struct {

--- a/pkg/tracing/traces.go
+++ b/pkg/tracing/traces.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package tracing
 
 // Interface for actual data traces

--- a/test/license_test.go
+++ b/test/license_test.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
 package test
 
 import (


### PR DESCRIPTION
BSL license stipulates that every source file should have one:

> All source files under BSL have a Change Date and the name of an Open
Source license in the header. The Change Date specifies when the source
file changes from BSL to the specified Open Source license. On the
Change Date, or the fourth anniversary of the first publicly available
distribution of the code under the BSL, whichever comes first, the code
automatically becomes available under the Change License (i.e., an Open
Source license).

Solution: use an automatic header insertion tool (go-license)
and [go-header](https://github.com/denis-tingaikin/go-header) lint
(golangci-run includes it)

Originally, I wanted to have empty comment lines between clauses of the
license header (copyright, reference to LICENSE and Change Date clause),
but go-license and go-header didn't quite agree on how to handle empty
lines and go-header was complaining and failing the check. They did
agree when I used a block comment to insert the license, but `go vet`
didn't: https://github.com/golang/go/issues/46169

So I just removed the empty comment lines to get this done for now.

Closes #13