### PR TITLE
Problem: redundant naming in some of the packages

### DIFF
--- a/cmd/bpxe/cmd/execute.go
+++ b/cmd/bpxe/cmd/execute.go
@@ -48,7 +48,7 @@ var executeCmd = &cobra.Command{
 			} else {
 				fmt.Println("Loaded an unnamed process")
 			}
-			proc := process.NewProcess(processElement, &document)
+			proc := process.New(processElement, &document)
 			if instance, err := proc.Instantiate(); err == nil {
 				traces := instance.Tracer.Subscribe()
 				err := instance.Run()

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -44,7 +44,7 @@ func (flow *Flow) SequenceFlow() *sequence_flow.SequenceFlow {
 		seqFlow, present := flow.definitions.FindBy(bpmn.ExactId(*flow.sequenceFlowId).
 			And(bpmn.ElementType((*bpmn.SequenceFlow)(nil))))
 		if present {
-			return sequence_flow.NewSequenceFlow(seqFlow.(*bpmn.SequenceFlow), flow.definitions)
+			return sequence_flow.New(seqFlow.(*bpmn.SequenceFlow), flow.definitions)
 		} else {
 			return nil
 		}
@@ -59,10 +59,10 @@ func (flow *Flow) SetTerminate(terminate flow_node.Terminate) {
 	flow.terminate = terminate
 }
 
-// Creates a new flow from a flow node
+// New creates a new flow from a flow node
 //
 // The flow does nothing until it is explicitly started.
-func NewFlow(definitions *bpmn.Definitions,
+func New(definitions *bpmn.Definitions,
 	current flow_node.FlowNodeInterface, tracer *tracing.Tracer,
 	flowNodeMapping *flow_node.FlowNodeMapping, flowWaitGroup *sync.WaitGroup,
 	idGenerator id.Generator, actionTransformer flow_node.ActionTransformer) *Flow {
@@ -193,7 +193,7 @@ func (flow *Flow) handleAdditionalSequenceFlow(sequenceFlow *sequence_flow.Seque
 	if err == nil {
 		if flowNode, found := flow.flowNodeMapping.ResolveElementToFlowNode(target); found {
 			var index int
-			newFlow := NewFlow(flow.definitions, flowNode, flow.tracer, flow.flowNodeMapping, flow.flowWaitGroup,
+			newFlow := New(flow.definitions, flowNode, flow.tracer, flow.flowNodeMapping, flow.flowWaitGroup,
 				flow.idGenerator, actionTransformer)
 			flowId = newFlow.Id()
 			if idPtr, present := sequenceFlow.Id(); present {

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -32,7 +32,7 @@ func TestTrueFormalExpression(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -75,7 +75,7 @@ func TestFalseFormalExpression(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/activity/harness.go
+++ b/pkg/flow_node/activity/harness.go
@@ -40,7 +40,7 @@ type incomingMessage struct {
 func (m incomingMessage) message() {}
 
 type Harness struct {
-	flow_node.FlowNode
+	flow_node.T
 	element         bpmn.FlowNodeInterface
 	runnerChannel   chan message
 	activity        Activity
@@ -96,7 +96,7 @@ func NewHarness(process *bpmn.Process,
 	constructor Constructor,
 	instanceBuilder event.InstanceBuilder,
 ) (node *Harness, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		element,
 		eventIngress, eventEgress,
@@ -129,7 +129,7 @@ func NewHarness(process *bpmn.Process,
 	}
 
 	node = &Harness{
-		FlowNode:        *flowNode,
+		T:               *flowNode,
 		element:         element,
 		runnerChannel:   make(chan message, len(flowNode.Incoming)*2+1),
 		activity:        activity,
@@ -159,8 +159,8 @@ func NewHarness(process *bpmn.Process,
 					return action
 				}
 			}
-			newFlow := flow.NewFlow(node.FlowNode.Definitions, catchEvent, node.FlowNode.Tracer,
-				node.FlowNode.FlowNodeMapping, node.FlowNode.FlowWaitGroup, node.idGenerator, actionTransformer)
+			newFlow := flow.New(node.T.Definitions, catchEvent, node.T.Tracer,
+				node.T.FlowNodeMapping, node.T.FlowWaitGroup, node.idGenerator, actionTransformer)
 			newFlow.Start()
 		}
 	}

--- a/pkg/flow_node/activity/task/task.go
+++ b/pkg/flow_node/activity/task/task.go
@@ -43,7 +43,7 @@ type cancelMessage struct {
 func (m cancelMessage) message() {}
 
 type Task struct {
-	flow_node.FlowNode
+	flow_node.T
 	element        *bpmn.Task
 	runnerChannel  chan message
 	activeBoundary chan bool
@@ -72,7 +72,7 @@ func NewTask(startEvent *bpmn.Task) activity.Constructor {
 		flowNodeMapping *flow_node.FlowNodeMapping,
 		flowWaitGroup *sync.WaitGroup,
 	) (node activity.Activity, err error) {
-		flowNode, err := flow_node.NewFlowNode(process,
+		flowNode, err := flow_node.New(process,
 			definitions,
 			&startEvent.FlowNode,
 			eventIngress, eventEgress,
@@ -83,7 +83,7 @@ func NewTask(startEvent *bpmn.Task) activity.Constructor {
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		taskNode := &Task{
-			FlowNode:       *flowNode,
+			T:              *flowNode,
 			element:        startEvent,
 			runnerChannel:  make(chan message, len(flowNode.Incoming)*2+1),
 			activeBoundary: make(chan bool),

--- a/pkg/flow_node/activity/task/tests/task_test.go
+++ b/pkg/flow_node/activity/task/tests/task_test.go
@@ -32,7 +32,7 @@ func TestTask(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/activity/tests/boundary_test.go
+++ b/pkg/flow_node/activity/tests/boundary_test.go
@@ -54,7 +54,7 @@ func testBoundaryEvent(t *testing.T, filename string, test func(visited map[stri
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	ready := make(chan bool)
 	if instance, err := proc.Instantiate(); err == nil {
 		if node, found := testDoc.FindBy(bpmn.ExactId("task")); found {
@@ -65,7 +65,7 @@ func testBoundaryEvent(t *testing.T, filename string, test func(visited map[stri
 				aTask.SetBody(func(task *task.Task, ctx context.Context) flow_node.Action {
 					select {
 					case <-ready:
-						return flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&task.FlowNode.Outgoing)}
+						return flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&task.T.Outgoing)}
 					case <-ctx.Done():
 						return flow_node.CompleteAction{}
 					}

--- a/pkg/flow_node/event/catch/catch_event.go
+++ b/pkg/flow_node/event/catch/catch_event.go
@@ -35,7 +35,7 @@ type processEventMessage struct {
 func (m processEventMessage) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element         *bpmn.CatchEvent
 	runnerChannel   chan message
 	activated       bool
@@ -48,7 +48,7 @@ func New(process *bpmn.Process, definitions *bpmn.Definitions,
 	intermediateCatchEvent *bpmn.CatchEvent, eventIngress event.ProcessEventConsumer,
 	eventEgress event.ProcessEventSource, tracer *tracing.Tracer, flowNodeMapping *flow_node.FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup, instanceBuilder event.InstanceBuilder) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&intermediateCatchEvent.FlowNode,
 		eventIngress, eventEgress,
@@ -65,7 +65,7 @@ func New(process *bpmn.Process, definitions *bpmn.Definitions,
 	}
 
 	node = &Node{
-		FlowNode:        *flowNode,
+		T:               *flowNode,
 		element:         intermediateCatchEvent,
 		runnerChannel:   make(chan message, len(flowNode.Incoming)*2+1),
 		activated:       false,

--- a/pkg/flow_node/event/catch/tests/catch_event_test.go
+++ b/pkg/flow_node/event/catch/tests/catch_event_test.go
@@ -114,7 +114,7 @@ func testEvent(t *testing.T, filename string, nodeId string, eventInstanceBuilde
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if eventInstanceBuilder != nil {
 		proc.SetEventInstanceBuilder(eventInstanceBuilder)
 	}

--- a/pkg/flow_node/event/end/end_event.go
+++ b/pkg/flow_node/event/end/end_event.go
@@ -35,7 +35,7 @@ type incomingMessage struct {
 func (m incomingMessage) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element              *bpmn.EndEvent
 	activated            bool
 	completed            bool
@@ -53,7 +53,7 @@ func New(process *bpmn.Process,
 	flowNodeMapping *flow_node.FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
 ) (node *Node, err error) {
-	flowNodePtr, err := flow_node.NewFlowNode(
+	flowNodePtr, err := flow_node.New(
 		process,
 		definitions,
 		&endEvent.FlowNode,
@@ -65,7 +65,7 @@ func New(process *bpmn.Process,
 	}
 	flowNode := *flowNodePtr
 	node = &Node{
-		FlowNode:             flowNode,
+		T:                    flowNode,
 		element:              endEvent,
 		activated:            false,
 		completed:            false,
@@ -95,13 +95,13 @@ func (node *Node) runner() {
 				continue
 			}
 
-			if _, err := node.FlowNode.EventIngress.ConsumeProcessEvent(
+			if _, err := node.T.EventIngress.ConsumeProcessEvent(
 				event.MakeEndEvent(node.element),
 			); err == nil {
 				node.completed = true
 				m.response <- flow_node.CompleteAction{}
 			} else {
-				node.FlowNode.Tracer.Trace(tracing.ErrorTrace{Error: err})
+				node.T.Tracer.Trace(tracing.ErrorTrace{Error: err})
 			}
 		default:
 		}

--- a/pkg/flow_node/event/end/tests/end_event_test.go
+++ b/pkg/flow_node/event/end/tests/end_event_test.go
@@ -32,7 +32,7 @@ func TestEndEvent(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/event/start/start_event.go
+++ b/pkg/flow_node/event/start/start_event.go
@@ -31,7 +31,7 @@ type nextActionMessage struct {
 func (m nextActionMessage) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element       *bpmn.StartEvent
 	runnerChannel chan message
 	activated     bool
@@ -48,7 +48,7 @@ func New(process *bpmn.Process,
 	flowWaitGroup *sync.WaitGroup,
 	idGenerator id.Generator,
 ) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&startEvent.FlowNode,
 		eventIngress, eventEgress,
@@ -58,7 +58,7 @@ func New(process *bpmn.Process,
 		return
 	}
 	node = &Node{
-		FlowNode:      *flowNode,
+		T:             *flowNode,
 		element:       startEvent,
 		runnerChannel: make(chan message, len(flowNode.Incoming)*2+1),
 		activated:     false,
@@ -93,8 +93,8 @@ func (node *Node) ConsumeProcessEvent(
 ) (result event.ConsumptionResult, err error) {
 	switch ev.(type) {
 	case *event.StartEvent:
-		newFlow := flow.NewFlow(node.FlowNode.Definitions, node, node.FlowNode.Tracer,
-			node.FlowNode.FlowNodeMapping, node.FlowNode.FlowWaitGroup, node.idGenerator, nil)
+		newFlow := flow.New(node.T.Definitions, node, node.T.Tracer,
+			node.T.FlowNodeMapping, node.T.FlowWaitGroup, node.idGenerator, nil)
 		newFlow.Start()
 	default:
 	}

--- a/pkg/flow_node/event/start/tests/start_event_test.go
+++ b/pkg/flow_node/event/start/tests/start_event_test.go
@@ -32,7 +32,7 @@ func TestStartEvent(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/flow_node.go
+++ b/pkg/flow_node/flow_node.go
@@ -19,7 +19,7 @@ import (
 	"bpxe.org/pkg/tracing"
 )
 
-type FlowNode struct {
+type T struct {
 	Id           bpmn.Id
 	Definitions  *bpmn.Definitions
 	Incoming     []sequence_flow.SequenceFlow
@@ -43,7 +43,7 @@ func sequenceFlows(process *bpmn.Process,
 			_, ok := e.(*bpmn.SequenceFlow)
 			return ok && exactId(e)
 		}); found {
-			result[i] = sequence_flow.MakeSequenceFlow(element.(*bpmn.SequenceFlow), definitions)
+			result[i] = sequence_flow.Make(element.(*bpmn.SequenceFlow), definitions)
 		} else {
 			err = errors.NotFoundError{Expected: identifier}
 			return
@@ -52,7 +52,7 @@ func sequenceFlows(process *bpmn.Process,
 	return
 }
 
-func NewFlowNode(process *bpmn.Process,
+func New(process *bpmn.Process,
 	definitions *bpmn.Definitions,
 	flowNode *bpmn.FlowNode,
 	eventIngress event.ProcessEventConsumer,
@@ -60,7 +60,7 @@ func NewFlowNode(process *bpmn.Process,
 	tracer *tracing.Tracer,
 	flowNodeMapping *FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
-) (node *FlowNode, err error) {
+) (node *T, err error) {
 	incoming, err := sequenceFlows(process, definitions, flowNode.Incomings())
 	if err != nil {
 		return
@@ -78,7 +78,7 @@ func NewFlowNode(process *bpmn.Process,
 	} else {
 		ownId = *ownIdPtr
 	}
-	node = &FlowNode{
+	node = &T{
 		Id:              ownId,
 		Definitions:     definitions,
 		Incoming:        incoming,

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -37,7 +37,7 @@ func TestNewFlowNode(t *testing.T) {
 	var waitGroup sync.WaitGroup
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
 		if flowNode, found := sampleDoc.FindBy(bpmn.ExactId("either")); found {
-			node, err := NewFlowNode(proc.(*bpmn.Process),
+			node, err := New(proc.(*bpmn.Process),
 				&defaultDefinitions,
 				&flowNode.(*bpmn.ParallelGateway).FlowNode,
 				event.VoidProcessEventConsumer{},

--- a/pkg/flow_node/gateway/event_based/event_based_gateway.go
+++ b/pkg/flow_node/gateway/event_based/event_based_gateway.go
@@ -33,7 +33,7 @@ type nextActionMessage struct {
 func (m nextActionMessage) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element       *bpmn.EventBasedGateway
 	runnerChannel chan message
 	activated     bool
@@ -42,7 +42,7 @@ type Node struct {
 func New(process *bpmn.Process, definitions *bpmn.Definitions, eventBasedGateway *bpmn.EventBasedGateway,
 	eventIngress event.ProcessEventConsumer, eventEgress event.ProcessEventSource, tracer *tracing.Tracer,
 	flowNodeMapping *flow_node.FlowNodeMapping, flowWaitGroup *sync.WaitGroup) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&eventBasedGateway.FlowNode,
 		eventIngress, eventEgress,
@@ -53,7 +53,7 @@ func New(process *bpmn.Process, definitions *bpmn.Definitions, eventBasedGateway
 	}
 
 	node = &Node{
-		FlowNode:      *flowNode,
+		T:             *flowNode,
 		element:       eventBasedGateway,
 		runnerChannel: make(chan message, len(flowNode.Incoming)*2+1),
 		activated:     false,

--- a/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
@@ -47,7 +47,7 @@ func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...ev
 		return
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/gateway/exclusive/exclusive_gateway.go
+++ b/pkg/flow_node/gateway/exclusive/exclusive_gateway.go
@@ -59,7 +59,7 @@ type probingReport struct {
 func (m probingReport) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element                 *bpmn.ExclusiveGateway
 	runnerChannel           chan message
 	defaultSequenceFlow     *sequence_flow.SequenceFlow
@@ -76,7 +76,7 @@ func New(process *bpmn.Process,
 	flowNodeMapping *flow_node.FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
 ) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&exclusiveGateway.FlowNode,
 		eventIngress, eventEgress,
@@ -92,7 +92,7 @@ func New(process *bpmn.Process,
 		if node, found := flowNode.Process.FindBy(bpmn.ExactId(*seqFlow).
 			And(bpmn.ElementType((*bpmn.SequenceFlow)(nil)))); found {
 			defaultSequenceFlow = new(sequence_flow.SequenceFlow)
-			*defaultSequenceFlow = sequence_flow.MakeSequenceFlow(
+			*defaultSequenceFlow = sequence_flow.Make(
 				node.(*bpmn.SequenceFlow),
 				definitions,
 			)
@@ -114,7 +114,7 @@ func New(process *bpmn.Process,
 	)
 
 	node = &Node{
-		FlowNode:                *flowNode,
+		T:                       *flowNode,
 		element:                 exclusiveGateway,
 		runnerChannel:           make(chan message, len(flowNode.Incoming)*2+1),
 		nonDefaultSequenceFlows: nonDefaultSequenceFlows,
@@ -149,7 +149,7 @@ func (node *Node) runner() {
 					// no successful non-default sequence flows
 					if node.defaultSequenceFlow == nil {
 						// exception (Table 13.2)
-						node.FlowNode.Tracer.Trace(tracing.ErrorTrace{
+						node.T.Tracer.Trace(tracing.ErrorTrace{
 							Error: NoEffectiveSequenceFlows{
 								ExclusiveGateway: node.element,
 							},
@@ -167,19 +167,19 @@ func (node *Node) runner() {
 						UnconditionalFlows: []int{0},
 					}
 				default:
-					node.FlowNode.Tracer.Trace(tracing.ErrorTrace{
+					node.T.Tracer.Trace(tracing.ErrorTrace{
 						Error: errors.InvalidArgumentError{
 							Expected: fmt.Sprintf("maximum 1 outgoing exclusive gateway (%s) flow",
-								node.FlowNode.Id),
+								node.T.Id),
 							Actual: len(flow),
 						},
 					})
 				}
 			} else {
-				node.FlowNode.Tracer.Trace(tracing.ErrorTrace{
+				node.T.Tracer.Trace(tracing.ErrorTrace{
 					Error: errors.InvalidStateError{
 						Expected: fmt.Sprintf("probing[%s] is to be present (exclusive gateway %s)",
-							m.flowId.String(), node.FlowNode.Id),
+							m.flowId.String(), node.T.Id),
 					},
 				})
 			}

--- a/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
@@ -34,7 +34,7 @@ func TestExclusiveGateway(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -87,7 +87,7 @@ func TestExclusiveGatewayWithDefault(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -141,7 +141,7 @@ func TestExclusiveGatewayWithNoDefault(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -197,7 +197,7 @@ func TestExclusiveGatewayIncompleteJoin(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
+++ b/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
@@ -65,7 +65,7 @@ type flowSync struct {
 }
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element                 *bpmn.InclusiveGateway
 	runnerChannel           chan message
 	defaultSequenceFlow     *sequence_flow.SequenceFlow
@@ -87,7 +87,7 @@ func New(process *bpmn.Process,
 	flowNodeMapping *flow_node.FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
 ) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&inclusiveGateway.FlowNode,
 		eventIngress, eventEgress,
@@ -103,7 +103,7 @@ func New(process *bpmn.Process,
 		if node, found := flowNode.Process.FindBy(bpmn.ExactId(*seqFlow).
 			And(bpmn.ElementType((*bpmn.SequenceFlow)(nil)))); found {
 			defaultSequenceFlow = new(sequence_flow.SequenceFlow)
-			*defaultSequenceFlow = sequence_flow.MakeSequenceFlow(
+			*defaultSequenceFlow = sequence_flow.Make(
 				node.(*bpmn.SequenceFlow),
 				definitions,
 			)
@@ -125,7 +125,7 @@ func New(process *bpmn.Process,
 	)
 
 	node = &Node{
-		FlowNode:                *flowNode,
+		T:                       *flowNode,
 		element:                 inclusiveGateway,
 		runnerChannel:           make(chan message, len(flowNode.Incoming)*2+1),
 		nonDefaultSequenceFlows: nonDefaultSequenceFlows,
@@ -163,7 +163,7 @@ func (node *Node) runner() {
 					// no successful non-default sequence flows
 					if node.defaultSequenceFlow == nil {
 						// exception (Table 13.2)
-						node.FlowNode.Tracer.Trace(tracing.ErrorTrace{
+						node.T.Tracer.Trace(tracing.ErrorTrace{
 							Error: NoEffectiveSequenceFlows{
 								InclusiveGateway: node.element,
 							},

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -34,7 +34,7 @@ func TestInclusiveGateway(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -93,7 +93,7 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -153,7 +153,7 @@ func TestInclusiveGatewayNoDefault(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/gateway/parallel/parallel_gateway.go
+++ b/pkg/flow_node/gateway/parallel/parallel_gateway.go
@@ -37,7 +37,7 @@ type incomingMessage struct {
 func (m incomingMessage) message() {}
 
 type Node struct {
-	flow_node.FlowNode
+	flow_node.T
 	element               *bpmn.ParallelGateway
 	runnerChannel         chan message
 	reportedIncomingFlows []int
@@ -54,7 +54,7 @@ func New(process *bpmn.Process,
 	flowNodeMapping *flow_node.FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
 ) (node *Node, err error) {
-	flowNode, err := flow_node.NewFlowNode(process,
+	flowNode, err := flow_node.New(process,
 		definitions,
 		&parallelGateway.FlowNode,
 		eventIngress, eventEgress,
@@ -65,7 +65,7 @@ func New(process *bpmn.Process,
 	}
 
 	node = &Node{
-		FlowNode:              *flowNode,
+		T:                     *flowNode,
 		element:               parallelGateway,
 		runnerChannel:         make(chan message, len(flowNode.Incoming)*2+1),
 		reportedIncomingFlows: make([]int, 0),

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -33,7 +33,7 @@ func TestParallelGateway(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -87,7 +87,7 @@ func TestParallelGatewayMtoN(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -140,7 +140,7 @@ func TestParallelGatewayNtoM(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -194,7 +194,7 @@ func TestParallelGatewayIncompleteJoin(t *testing.T) {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
 	processElement := (*testDoc.Processes())[0]
-	proc := process.NewProcess(&processElement, &testDoc)
+	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -19,15 +19,15 @@ type Model struct {
 	processes []process.Process
 }
 
-func NewModel(element *bpmn.Definitions) *Model {
-	return NewModelWithIdGenerator(element, id.DefaultIdGeneratorBuilder)
+func New(element *bpmn.Definitions) *Model {
+	return NewWithIdGenerator(element, id.DefaultIdGeneratorBuilder)
 }
 
-func NewModelWithIdGenerator(element *bpmn.Definitions, idGeneratorBuilder id.GeneratorBuilder) *Model {
+func NewWithIdGenerator(element *bpmn.Definitions, idGeneratorBuilder id.GeneratorBuilder) *Model {
 	procs := element.Processes()
 	processes := make([]process.Process, len(*procs))
 	for i := range *procs {
-		processes[i] = process.MakeProcess(&(*procs)[i], element, idGeneratorBuilder)
+		processes[i] = process.Make(&(*procs)[i], element, idGeneratorBuilder)
 	}
 	return &Model{
 		Element:   element,

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -38,7 +38,7 @@ func TestFindProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("XML unmarshalling error: %v", err)
 	}
-	model := NewModel(&sampleDoc)
+	model := New(&sampleDoc)
 	if proc, found := model.FindProcessBy(exactId("sample")); found {
 		if id, present := proc.Element.Id(); present {
 			assert.Equal(t, *id, "sample")

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -26,7 +26,7 @@ func (process *Process) SetEventInstanceBuilder(eventInstanceBuilder event.Insta
 	process.eventInstanceBuilder = eventInstanceBuilder
 }
 
-func MakeProcess(element *bpmn.Process, definitions *bpmn.Definitions, idGeneratorBuilder id.GeneratorBuilder) Process {
+func Make(element *bpmn.Process, definitions *bpmn.Definitions, idGeneratorBuilder id.GeneratorBuilder) Process {
 	return Process{
 		Element:          element,
 		Definitions:      definitions,
@@ -35,13 +35,13 @@ func MakeProcess(element *bpmn.Process, definitions *bpmn.Definitions, idGenerat
 	}
 }
 
-func NewProcess(element *bpmn.Process, definitions *bpmn.Definitions) *Process {
-	return NewProcessWithIdGeneratorBuilder(element, definitions, id.DefaultIdGeneratorBuilder)
+func New(element *bpmn.Process, definitions *bpmn.Definitions) *Process {
+	return NewWithIdGeneratorBuilder(element, definitions, id.DefaultIdGeneratorBuilder)
 }
 
-func NewProcessWithIdGeneratorBuilder(element *bpmn.Process, definitions *bpmn.Definitions,
+func NewWithIdGeneratorBuilder(element *bpmn.Process, definitions *bpmn.Definitions,
 	idGeneratorBuilder id.GeneratorBuilder) *Process {
-	process := MakeProcess(element, definitions, idGeneratorBuilder)
+	process := Make(element, definitions, idGeneratorBuilder)
 	return &process
 }
 

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -31,7 +31,7 @@ func TestExplicitInstantiation(t *testing.T) {
 	}
 
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
-		process := NewProcess(proc.(*bpmn.Process), &defaultDefinitions)
+		process := New(proc.(*bpmn.Process), &defaultDefinitions)
 		instance, err := process.Instantiate()
 		assert.Nil(t, err)
 		assert.NotNil(t, instance)

--- a/pkg/sequence_flow/sequence_flow.go
+++ b/pkg/sequence_flow/sequence_flow.go
@@ -20,15 +20,15 @@ type SequenceFlow struct {
 	definitions *bpmn.Definitions
 }
 
-func MakeSequenceFlow(sequenceFlow *bpmn.SequenceFlow, definitions *bpmn.Definitions) SequenceFlow {
+func Make(sequenceFlow *bpmn.SequenceFlow, definitions *bpmn.Definitions) SequenceFlow {
 	return SequenceFlow{
 		SequenceFlow: sequenceFlow,
 		definitions:  definitions,
 	}
 }
 
-func NewSequenceFlow(sequenceFlow *bpmn.SequenceFlow, definitions *bpmn.Definitions) *SequenceFlow {
-	seqFlow := MakeSequenceFlow(sequenceFlow, definitions)
+func New(sequenceFlow *bpmn.SequenceFlow, definitions *bpmn.Definitions) *SequenceFlow {
+	seqFlow := Make(sequenceFlow, definitions)
 	return &seqFlow
 }
 


### PR DESCRIPTION
This leads to code like this:

```go
process.NewProcess(...)
```

Solution: rename most notorious examples

Now it looks more like this:

```go
process.New(...)
```