### PR TITLE
Problem: intermittent test timeouts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
         go-version: 1.16
 
     - name: Test
-      run: go test ./...
+      run: go test -count=100 ./...
       
     - name: Build bpxe command
       run: go build -o bin ./cmd/bpxe

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: check ## Build bpxe
 	go build -o bin ./cmd/bpxe
 
 test: check ## Run tests
-	go test ./...
+	go test -count=100 ./...
 
 headers:
 	@go-license --config=.license.yml $(wildcard **/**.go **/**/**.go **/**/**/**.go **/**/**/**/**.go **/**/**/**/**/**.go)

--- a/pkg/flow_node/event/catch/tests/catch_event_test.go
+++ b/pkg/flow_node/event/catch/tests/catch_event_test.go
@@ -66,7 +66,7 @@ func TestMultipleParallelEvent(t *testing.T) {
 	select {
 	case <-ch:
 		t.Fatal("should not succeed")
-	case <-time.After(time.Millisecond * 500):
+	case <-time.After(time.Millisecond * 100):
 	}
 
 }
@@ -118,8 +118,11 @@ func testEvent(t *testing.T, filename string, nodeId string, eventInstanceBuilde
 	if eventInstanceBuilder != nil {
 		proc.SetEventInstanceBuilder(eventInstanceBuilder)
 	}
-	if instance, err := proc.Instantiate(); err == nil {
-		traces := instance.Tracer.SubscribeChannel(make(chan tracing.Trace, 64))
+
+	tracer := tracing.NewTracer()
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 64))
+
+	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
 		err := instance.Run()
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -223,7 +223,7 @@ func TestParallelGatewayIncompleteJoin(t *testing.T) {
 				default:
 					t.Logf("%#v", trace)
 				}
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(100 * time.Millisecond):
 				break loop
 			}
 		}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -45,8 +45,8 @@ func NewWithIdGeneratorBuilder(element *bpmn.Process, definitions *bpmn.Definiti
 	return &process
 }
 
-func (process *Process) Instantiate() (instance *Instance, err error) {
-	instance, err = NewInstance(process)
+func (process *Process) Instantiate(options ...InstanceOption) (instance *Instance, err error) {
+	instance, err = NewInstance(process, options...)
 	if err != nil {
 		return
 	}

--- a/test/license_test.go
+++ b/test/license_test.go
@@ -27,65 +27,69 @@ type dependencyAlert struct {
 	confidence float32
 }
 
+var dependencyLicenseOnce sync.Once
+
 func TestDependencyLicenses(t *testing.T) {
+	// No need to re-run it on `-count=N` where N>1
+	dependencyLicenseOnce.Do(func() {
+		// Get dependencies
+		file, err := ioutil.ReadFile("../vendor/modules.txt")
+		assert.Nil(t, err)
+		modules := string(file)
+		scanner := bufio.NewScanner(strings.NewReader(modules))
+		dependencies := make([]string, 0)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "# ") {
+				// found a dependency
+				dependency := strings.Split(line, " ")[1]
+				dependencies = append(dependencies, dependency)
 
-	// Get dependencies
-	file, err := ioutil.ReadFile("../vendor/modules.txt")
-	assert.Nil(t, err)
-	modules := string(file)
-	scanner := bufio.NewScanner(strings.NewReader(modules))
-	dependencies := make([]string, 0)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "# ") {
-			// found a dependency
-			dependency := strings.Split(line, " ")[1]
-			dependencies = append(dependencies, dependency)
-
-		}
-	}
-
-	// Start scanning them
-	var wg sync.WaitGroup
-	alerts := make(chan dependencyAlert, len(dependencies))
-	for _, dependency := range dependencies {
-		wg.Add(1)
-		go func(dependency string) {
-			defer wg.Done()
-			f, err := filer.FromDirectory(fmt.Sprintf("../vendor/%s", dependency))
-			assert.Nil(t, err)
-			licenses, err := licensedb.Detect(f)
-			assert.Nil(t, err)
-			if len(licenses) == 0 {
-				alerts <- dependencyAlert{
-					dependency: dependency,
-					license:    "none",
-					confidence: 1,
-				}
-				return
 			}
-			for license := range licenses {
-				if strings.Contains(license, "GPL") {
+		}
+
+		// Start scanning them
+		var wg sync.WaitGroup
+		alerts := make(chan dependencyAlert, len(dependencies))
+		for _, dependency := range dependencies {
+			wg.Add(1)
+			go func(dependency string) {
+				defer wg.Done()
+				f, err := filer.FromDirectory(fmt.Sprintf("../vendor/%s", dependency))
+				assert.Nil(t, err)
+				licenses, err := licensedb.Detect(f)
+				assert.Nil(t, err)
+				if len(licenses) == 0 {
 					alerts <- dependencyAlert{
 						dependency: dependency,
-						license:    license,
-						confidence: licenses[license].Confidence,
+						license:    "none",
+						confidence: 1,
 					}
+					return
 				}
-				return
-			}
-		}(dependency)
+				for license := range licenses {
+					if strings.Contains(license, "GPL") {
+						alerts <- dependencyAlert{
+							dependency: dependency,
+							license:    license,
+							confidence: licenses[license].Confidence,
+						}
+					}
+					return
+				}
+			}(dependency)
 
-	}
-	// Wait until the scan is done
-	wg.Wait()
-loop:
-	for {
-		select {
-		case alert := <-alerts:
-			t.Fatalf("%s indicates %s license with %v confidence", alert.dependency, alert.license, alert.confidence)
-		default:
-			break loop
 		}
-	}
+		// Wait until the scan is done
+		wg.Wait()
+	loop:
+		for {
+			select {
+			case alert := <-alerts:
+				t.Fatalf("%s indicates %s license with %v confidence", alert.dependency, alert.license, alert.confidence)
+			default:
+				break loop
+			}
+		}
+	})
 }


### PR DESCRIPTION
This primarily happens in boundary_test.go

Solution: ensure observation of listening trace

The boundary test assumes that a boundary event is already
listening post-instantiation of the process. However,
this is not necessarily true, because this is timing-dependant
as all the flow nodes are independent goroutines.

So, we need to wait until a trace indicating boundary event is
listening has been received. This check used to be in this test
but was erroneously removed when it didn't work as expected.

The problem was that the test subscribed to the tracer too late --
at a point when listening trace might have been sent out as process
instantiation provisions activity harness which starts boundary flows
and respective traces are emitted.

This hinges on the way tracers are assumed to be created. They are created
upon process instantiation. There's no way to create a tracer before
the process is instantiated. This change fixes this oversight. It adds
`process.InstanceOption` type that allows to modify instance right after
it is constructed by `process.NewInstance`. First such option is `WithTracer`
that'll set a custom tracer in the instance.

With this change, the tests can now create their own tracer ahead of time
and pass it to instances.

To celebrate tests no longer timing out (fingers crossed!) I'm upping test count
for test runs to 100 to have better assurances every time we run the tests.
This required me to decrease timeouts in some of the tests so that they finish
sooner. I hope they can be improved upon later to ensure `time.After` doesn't
need to be used for testing at all. I've also ensured license check test
runs only once because it doesn't need to be ran more than once and it's pretty
slow.