### PR TITLE
Problem: test runs are a bit slow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ all: check ## Build bpxe
 	go build -o bin ./cmd/bpxe
 
 test: check ## Run tests
-	go test -count=100 ./...
+	go test -count=100 ./pkg/...
+	go test ./test/...
 
 headers:
 	@go-license --config=.license.yml $(wildcard **/**.go **/**/**.go **/**/**/**.go **/**/**/**/**.go **/**/**/**/**/**.go)

--- a/pkg/flow_node/event/catch/catch_event.go
+++ b/pkg/flow_node/event/catch/catch_event.go
@@ -104,6 +104,7 @@ loop:
 				}
 				continue loop
 			matched:
+				node.Tracer.Trace(EventObservedTrace{Node: node.element, Event: m.event})
 				for _, matched := range node.matchedEvents {
 					if !matched && node.element.ParallelMultiple() {
 						continue loop

--- a/pkg/flow_node/gateway/parallel/parallel_gateway.go
+++ b/pkg/flow_node/gateway/parallel/parallel_gateway.go
@@ -104,6 +104,7 @@ loop:
 		case nextActionMessage:
 			node.awaitingActions = append(node.awaitingActions, m.response)
 			node.flowWhenReady()
+			node.Tracer.Trace(IncomingFlowProcessedTrace{Node: node.element, Flow: m.flow})
 		default:
 		}
 	}

--- a/pkg/flow_node/gateway/parallel/traces.go
+++ b/pkg/flow_node/gateway/parallel/traces.go
@@ -6,24 +6,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package catch
+package parallel
 
 import (
 	"bpxe.org/pkg/bpmn"
-	"bpxe.org/pkg/event"
+	"bpxe.org/pkg/flow/flow_interface"
 )
 
-type ActiveListeningTrace struct {
-	Node *bpmn.CatchEvent
+// IncomingFlowProcessedTrace signals that a particular flow
+// has been processed. If any action have been taken, it already happened
+type IncomingFlowProcessedTrace struct {
+	Node *bpmn.ParallelGateway
+	Flow flow_interface.T
 }
 
-func (t ActiveListeningTrace) TraceInterface() {}
-
-// EventObservedTrace signals the fact that a particular event
-// has been in fact observed by the node
-type EventObservedTrace struct {
-	Node  *bpmn.CatchEvent
-	Event event.ProcessEvent
-}
-
-func (t EventObservedTrace) TraceInterface() {}
+func (t IncomingFlowProcessedTrace) TraceInterface() {}


### PR DESCRIPTION
Now that we run 100 of each tests in each invocation of
`make test`, use of timeouts in tests has become a bit of a burden
as the testing iterations became longer.

Solution: make waiting for timeouts unnecessary

Two new traces were introduced:

`event/catch.EventObservedTrace` to signal that `event/catch.Node`
has observed a particular event. This allowed us to make sure that
the events have or have not reached the event catcher

`gateway/parallel.IncomingFlowProcessedTrace` to signal that an incoming
flow has been processed (so, any outgoing flow already happened)

These traces allowed me to rewrite tests in such a way that the expectation
of timeouts is no longer necessary.

I've also broke out license testing from `count=100` run so that it can be
fully cached between invocations of `make test`. I've not done this for CI
as there's still a check in that test to ensure it runs only once.