### PR TITLE
Problem: inclusive gateway tests hanging

### DIFF
--- a/pkg/flow_node/gateway/inclusive/flow_tracker.go
+++ b/pkg/flow_node/gateway/inclusive/flow_tracker.go
@@ -23,53 +23,108 @@ type flowTracker struct {
 	flows      map[id.Id]bpmn.Id
 	activityCh chan struct{}
 	lock       sync.RWMutex
+	element    *bpmn.InclusiveGateway
 }
 
 func (tracker *flowTracker) activity() <-chan struct{} {
 	return tracker.activityCh
 }
 
-func newFlowTracker(tracer *tracing.Tracer) *flowTracker {
+func newFlowTracker(tracer *tracing.Tracer, element *bpmn.InclusiveGateway) *flowTracker {
 	tracker := flowTracker{
 		traces:     tracer.Subscribe(),
 		shutdownCh: make(chan bool),
 		flows:      make(map[id.Id]bpmn.Id),
 		activityCh: make(chan struct{}),
+		element:    element,
 	}
+	// Lock the tracker until it has caught up enough
+	// to see the incoming flow for the node
+	tracker.lock.Lock()
 	go tracker.run()
 	return &tracker
 }
 
 func (tracker *flowTracker) run() {
+	// As per note in the constructor, we're starting in a locked mode
+	locked := true
+	// Flag for notifying the node about activity
+	notify := false
+	// Indicates whether the tracker has observed a flow
+	// that reaches the node that uses this tracker.
+	// This is important because if the node will invoke
+	// `activeFlowsInCohort` before the tracker has caught up,
+	// it'll return an empty list, and the node will assume that
+	// there's no other flow to wait for, and will proceed (which
+	// is incorrect)
+	reachedNode := false
 	for {
 		select {
 		case trace := <-tracker.traces:
-			switch t := trace.(type) {
-			case flow.FlowTrace:
-				tracker.lock.Lock()
-				for _, snapshot := range t.Flows {
-					if idPtr, present := t.Source.Id(); present {
-						_, ok := tracker.flows[snapshot.Id()]
-						_, isInclusive := t.Source.(*bpmn.InclusiveGateway)
-						if !ok || isInclusive {
-							tracker.flows[snapshot.Id()] = *idPtr
-						}
-					}
-				}
-				tracker.lock.Unlock()
-				tracker.activityCh <- struct{}{}
-			case flow.FlowTerminationTrace:
-				tracker.lock.Lock()
-				delete(tracker.flows, t.FlowId)
-				tracker.lock.Unlock()
-				tracker.activityCh <- struct{}{}
-			default:
-				continue
-			}
+			locked, notify, reachedNode = tracker.handleTrace(locked, trace, notify, reachedNode)
+			// continue draining
+			continue
 		case <-tracker.shutdownCh:
+			if locked {
+				tracker.lock.Unlock()
+			}
+			return
+		default:
+			// Nothing else is coming in, unlock if locked
+			if locked && reachedNode {
+				tracker.lock.Unlock()
+				if notify {
+					tracker.activityCh <- struct{}{}
+					notify = false
+				}
+				locked = false
+			}
+			// and now proceed with the second select to wait
+			// for an event without doing busy work (this `default` clause)
+		}
+		select {
+		case trace := <-tracker.traces:
+			locked, notify, reachedNode = tracker.handleTrace(locked, trace, notify, reachedNode)
+		case <-tracker.shutdownCh:
+			if locked {
+				tracker.lock.Unlock()
+			}
 			return
 		}
 	}
+}
+
+func (tracker *flowTracker) handleTrace(locked bool, trace tracing.Trace, notify bool, reachedNode bool) (bool, bool, bool) {
+	if !locked {
+		// Lock tracker records until messages are drained
+		tracker.lock.Lock()
+		locked = true
+	}
+	switch t := trace.(type) {
+	case flow.FlowTrace:
+		for _, snapshot := range t.Flows {
+			// If we haven't reached the node
+			if !reachedNode {
+				// Try and see if this flow is the one that goes into it
+				targetId := snapshot.SequenceFlow().TargetRef()
+				if idPtr, present := tracker.element.Id(); present {
+					reachedNode = *idPtr == *targetId
+				}
+			}
+			if idPtr, present := t.Source.Id(); present {
+				_, ok := tracker.flows[snapshot.Id()]
+				_, isInclusive := t.Source.(*bpmn.InclusiveGateway)
+				if !ok || isInclusive {
+					tracker.flows[snapshot.Id()] = *idPtr
+				}
+			}
+		}
+		notify = true
+	case flow.FlowTerminationTrace:
+		delete(tracker.flows, t.FlowId)
+		notify = true
+	}
+	return locked, notify, reachedNode
 }
 
 func (tracker *flowTracker) shutdown() {

--- a/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
+++ b/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
@@ -73,6 +73,7 @@ type Node struct {
 	probing                 *chan flow_node.Action
 	activated               *flowSync
 	awaiting                []id.Id
+	arrived                 []id.Id
 	sync                    []chan flow_node.Action
 	*flowTracker
 	synchronized bool
@@ -130,7 +131,7 @@ func New(process *bpmn.Process,
 		runnerChannel:           make(chan message, len(flowNode.Incoming)*2+1),
 		nonDefaultSequenceFlows: nonDefaultSequenceFlows,
 		defaultSequenceFlow:     defaultSequenceFlow,
-		flowTracker:             newFlowTracker(tracer),
+		flowTracker:             newFlowTracker(tracer, inclusiveGateway),
 	}
 	go node.runner()
 	return
@@ -183,24 +184,18 @@ func (node *Node) runner() {
 						node.sync = append(node.sync, m.response)
 						node.probing = &m.response
 						// and now we wait until the probe has returned
-						continue
 					}
+					continue
 				}
 				if node.activated == nil {
 					// Haven't been activated yet
 					node.activated = &flowSync{response: m.response, flow: m.flow}
 					node.awaiting = node.flowTracker.activeFlowsInCohort(m.flow.Id())
+					node.arrived = []id.Id{m.flow.Id()}
 					node.sync = make([]chan flow_node.Action, 0)
 				} else {
 					// Already activated
-					for i, awaitingId := range node.awaiting {
-						if awaitingId == m.flow.Id() {
-							// Remove
-							node.awaiting[i] = node.awaiting[len(node.awaiting)-1]
-							node.awaiting = node.awaiting[:len(node.awaiting)-1]
-							break
-						}
-					}
+					node.arrived = append(node.arrived, m.flow.Id())
 					node.sync = append(node.sync, m.response)
 				}
 				node.trySync()
@@ -208,7 +203,7 @@ func (node *Node) runner() {
 			default:
 			}
 		case <-activity:
-			if node.activated != nil {
+			if !node.synchronized && node.activated != nil {
 				node.awaiting = node.flowTracker.activeFlowsInCohort(node.activated.flow.Id())
 				node.trySync()
 			}
@@ -217,21 +212,31 @@ func (node *Node) runner() {
 }
 
 func (node *Node) trySync() {
-	if !node.synchronized && len(node.awaiting) == 0 {
-		// We've got everybody
-		anId := node.activated.flow.Id()
-		// Probe outgoing sequence flow using the first flow
-		node.activated.response <- flow_node.ProbeAction{
-			SequenceFlows: node.nonDefaultSequenceFlows,
-			ProbeReport: func(indices []int) {
-				node.runnerChannel <- probingReport{
-					result: indices,
-					flowId: anId,
+	if !node.synchronized && len(node.arrived) >= len(node.awaiting) {
+		// Have we got everybody?
+		matches := 0
+		for i := range node.arrived {
+			for j := range node.awaiting {
+				if node.awaiting[j] == node.arrived[i] {
+					matches++
 				}
-			},
+			}
 		}
+		if matches == len(node.awaiting) {
+			anId := node.activated.flow.Id()
+			// Probe outgoing sequence flow using the first flow
+			node.activated.response <- flow_node.ProbeAction{
+				SequenceFlows: node.nonDefaultSequenceFlows,
+				ProbeReport: func(indices []int) {
+					node.runnerChannel <- probingReport{
+						result: indices,
+						flowId: anId,
+					}
+				},
+			}
 
-		node.synchronized = true
+			node.synchronized = true
+		}
 	}
 }
 

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -35,8 +35,9 @@ func TestInclusiveGateway(t *testing.T) {
 	}
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
-	if instance, err := proc.Instantiate(); err == nil {
-		traces := instance.Tracer.Subscribe()
+	tracer := tracing.NewTracer()
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
+	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
 		err := instance.Run()
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
@@ -94,8 +95,9 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 	}
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
-	if instance, err := proc.Instantiate(); err == nil {
-		traces := instance.Tracer.Subscribe()
+	tracer := tracing.NewTracer()
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
+	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
 		err := instance.Run()
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)


### PR DESCRIPTION
These timeouts are somewhat unpredictable, but they
happen fairly regularly.

Solution: re-engineer parts of inclusive gateway

Firstly, some assurances were made in the flow tracker. Particularly,
it will now attempt to drain the traces in full before allowing
`activeFlowsInCohort` to return a list of active flows in the cohort (via
the use of the lock); nor will it attempt sending an activity notification
until it's drained the traces. There was one particular situation where
the flow tracker was locking up: it was attempting to send an activity notification
while holding the lock. This meant that if the inclusive gateway node was
calling `activeFlowsInCohort` and waiting for the lock there, the flow tracker
itself would block on attempting to send an activity notification. Increasing
its buffer helps to a degree, but its hard to predict the size of the queue
necessary. Either way, sending multiple notifications for a single drain doesn't
seem to make a lot of sense.

While working on that, I also wanted to make sure that the tracker is indeed
always "up to speed": it will now lock up at the construction time and will
not unlock until it has observed the flow that comes into the node.

Secondly, inclusive gateway was redesigned to make tracking of flows that it is
waiting on a bit easier to reason about. Initially, it was deleting elements from
`awaiting` list when they came in, and this meant that if that list was to change
due to updates from the tracker, there could be an inconsistent view of what's
happening. Now it's tracking arrived flows separately and compares them with the
list of what it is awaiting for.

Thirdly, the test was updated to use its own tracker to avoid missing out on
anything.

However, I was still experiencing intermittent timeouts in tests. So I dug deeper
and I discovered that occasionally traces come in a wrong order (and they were
definitely not supposed to do that!). The culprit was in the `flow` package:
`handleAdditionalSequenceFlow` eagerly started new flows before the current
flow had a chance to log the flow, resulting in a wrong order. This issue
has been addressed.

Note: I've observed a slowdown of inclusive gateway after this update. I think
it's about 2.5 times slower now. Not great, but perhaps it is something that can
be addressed down the road and optimized.