### PR TITLE
Problem: wrong word in `process/Instance.Run()` comment

### DIFF
--- a/pkg/process/instance.go
+++ b/pkg/process/instance.go
@@ -210,7 +210,7 @@ func (instance *Instance) RegisterProcessEventConsumer(ev event.ProcessEventCons
 func (instance *Instance) Run() (err error) {
 	// Start cease flow monitor
 	go instance.ceaseFlowMonitor()()
-	// Implicit start
+	// Explicit start
 	evt := event.MakeStartEvent()
 	_, err = instance.ConsumeProcessEvent(&evt)
 	if err != nil {


### PR DESCRIPTION
It says "Implicit start", but it's obviously not true. We're
explicitly sending a Start Event in.

Solution: change it to "Explicit start"