### PR TITLE
Problem: tests are still a bit slow

### DIFF
--- a/internal/package.go
+++ b/internal/package.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package internal

--- a/internal/test.go
+++ b/internal/test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package internal
+
+import (
+	"embed"
+	"encoding/xml"
+	"log"
+
+	"bpxe.org/pkg/bpmn"
+)
+
+func LoadTestFile(filename string, testdata embed.FS, definitions *bpmn.Definitions) {
+	var err error
+	src, err := testdata.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("Can't read file %s: %v", filename, err)
+	}
+	err = xml.Unmarshal(src, definitions)
+	if err != nil {
+		log.Fatalf("XML unmarshalling error in %s: %v", filename, err)
+	}
+}

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -9,9 +9,9 @@
 package tests
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/process"
@@ -20,19 +20,15 @@ import (
 	_ "github.com/stretchr/testify/assert"
 )
 
+var testCondExpr bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/condexpr.bpmn", testdata, &testCondExpr)
+}
+
 func TestTrueFormalExpression(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/condexpr.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testCondExpr.Processes())[0]
+	proc := process.New(&processElement, &testCondExpr)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -63,19 +59,15 @@ func TestTrueFormalExpression(t *testing.T) {
 	}
 }
 
+var testCondExprFalse bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/condexpr_false.bpmn", testdata, &testCondExprFalse)
+}
+
 func TestFalseFormalExpression(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/condexpr_false.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testCondExprFalse.Processes())[0]
+	proc := process.New(&processElement, &testCondExprFalse)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/activity/task/tests/task_test.go
+++ b/pkg/flow_node/activity/task/tests/task_test.go
@@ -9,9 +9,9 @@
 package tests
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/process"
@@ -20,19 +20,15 @@ import (
 	_ "github.com/stretchr/testify/assert"
 )
 
+var testTask bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/task.bpmn", testdata, &testTask)
+}
+
 func TestTask(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/task.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testTask.Processes())[0]
+	proc := process.New(&processElement, &testTask)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/event/end/tests/end_event_test.go
+++ b/pkg/flow_node/event/end/tests/end_event_test.go
@@ -9,9 +9,9 @@
 package tests
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/process"
@@ -20,17 +20,13 @@ import (
 	_ "github.com/stretchr/testify/assert"
 )
 
+var testDoc bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/start.bpmn", testdata, &testDoc)
+}
+
 func TestEndEvent(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/start.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {

--- a/pkg/flow_node/event/start/tests/start_event_test.go
+++ b/pkg/flow_node/event/start/tests/start_event_test.go
@@ -9,9 +9,9 @@
 package tests
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/process"
@@ -20,17 +20,13 @@ import (
 	_ "github.com/stretchr/testify/assert"
 )
 
+var testDoc bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/start.bpmn", testdata, &testDoc)
+}
+
 func TestStartEvent(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/start.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -9,10 +9,10 @@
 package flow_node
 
 import (
-	"encoding/xml"
 	"sync"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/tracing"
@@ -22,18 +22,13 @@ import (
 
 var defaultDefinitions = bpmn.DefaultDefinitions()
 
-func TestNewFlowNode(t *testing.T) {
-	var sampleDoc bpmn.Definitions
-	var err error
-	sample, err := testdata.ReadFile("testdata/sample.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(sample, &sampleDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
+var sampleDoc bpmn.Definitions
 
+func init() {
+	internal.LoadTestFile("testdata/sample.bpmn", testdata, &sampleDoc)
+}
+
+func TestNewFlowNode(t *testing.T) {
 	var waitGroup sync.WaitGroup
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
 		if flowNode, found := sampleDoc.FindBy(bpmn.ExactId("either")); found {

--- a/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
@@ -10,9 +10,9 @@ package tests
 
 import (
 	"context"
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/flow"
@@ -21,6 +21,12 @@ import (
 	"bpxe.org/pkg/tracing"
 	"github.com/stretchr/testify/assert"
 )
+
+var testDoc bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/event_based_gateway.bpmn", testdata, &testDoc)
+}
 
 func TestEventBasedGateway(t *testing.T) {
 	testEventBasedGateway(t, func(reached map[string]int) {
@@ -34,18 +40,6 @@ func TestEventBasedGateway(t *testing.T) {
 }
 
 func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...event.ProcessEvent) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/event_based_gateway.bpmn")
-	if err != nil {
-		t.Errorf("Can't read file: %v", err)
-		return
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Errorf("XML unmarshalling error: %v", err)
-		return
-	}
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {

--- a/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
@@ -9,10 +9,10 @@
 package tests
 
 import (
-	"encoding/xml"
 	"errors"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/flow_node/gateway/exclusive"
@@ -22,19 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testExclusiveGateway bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/exclusive_gateway.bpmn", testdata, &testExclusiveGateway)
+}
+
 func TestExclusiveGateway(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/exclusive_gateway.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testExclusiveGateway.Processes())[0]
+	proc := process.New(&processElement, &testExclusiveGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -75,19 +71,15 @@ func TestExclusiveGateway(t *testing.T) {
 	}
 }
 
+var testExclusiveGatewayWithDefault bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/exclusive_gateway_default.bpmn", testdata, &testExclusiveGatewayWithDefault)
+}
+
 func TestExclusiveGatewayWithDefault(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/exclusive_gateway_default.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testExclusiveGatewayWithDefault.Processes())[0]
+	proc := process.New(&processElement, &testExclusiveGatewayWithDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -129,19 +121,15 @@ func TestExclusiveGatewayWithDefault(t *testing.T) {
 	}
 }
 
+var testExclusiveGatewayWithNoDefault bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/exclusive_gateway_no_default.bpmn", testdata, &testExclusiveGatewayWithNoDefault)
+}
+
 func TestExclusiveGatewayWithNoDefault(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/exclusive_gateway_no_default.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testExclusiveGatewayWithNoDefault.Processes())[0]
+	proc := process.New(&processElement, &testExclusiveGatewayWithNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -185,19 +173,15 @@ func TestExclusiveGatewayWithNoDefault(t *testing.T) {
 	}
 }
 
+var testExclusiveGatewayIncompleteJoin bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/exclusive_gateway_multiple_incoming.bpmn", testdata, &testExclusiveGatewayIncompleteJoin)
+}
+
 func TestExclusiveGatewayIncompleteJoin(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/exclusive_gateway_multiple_incoming.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testExclusiveGatewayIncompleteJoin.Processes())[0]
+	proc := process.New(&processElement, &testExclusiveGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -9,10 +9,10 @@
 package tests
 
 import (
-	"encoding/xml"
 	"errors"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/flow_node/gateway/inclusive"
@@ -22,19 +22,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testInclusiveGateway bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/inclusive_gateway.bpmn", testdata, &testInclusiveGateway)
+}
+
 func TestInclusiveGateway(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/inclusive_gateway.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testInclusiveGateway.Processes())[0]
+	proc := process.New(&processElement, &testInclusiveGateway)
 	tracer := tracing.NewTracer()
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
@@ -82,19 +78,15 @@ func TestInclusiveGateway(t *testing.T) {
 	}
 }
 
+var testInclusiveGatewayDefault bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/inclusive_gateway_default.bpmn", testdata, &testInclusiveGatewayDefault)
+}
+
 func TestInclusiveGatewayDefault(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/inclusive_gateway_default.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testInclusiveGatewayDefault.Processes())[0]
+	proc := process.New(&processElement, &testInclusiveGatewayDefault)
 	tracer := tracing.NewTracer()
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
@@ -143,19 +135,15 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 	}
 }
 
+var testInclusiveGatewayNoDefault bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/inclusive_gateway_no_default.bpmn", testdata, &testInclusiveGatewayNoDefault)
+}
+
 func TestInclusiveGatewayNoDefault(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/inclusive_gateway_no_default.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testInclusiveGatewayNoDefault.Processes())[0]
+	proc := process.New(&processElement, &testInclusiveGatewayNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -9,9 +9,9 @@
 package tests
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/flow_node/gateway/parallel"
@@ -21,19 +21,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testParallelGateway bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/parallel_gateway_fork_join.bpmn", testdata, &testParallelGateway)
+}
+
 func TestParallelGateway(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/parallel_gateway_fork_join.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testParallelGateway.Processes())[0]
+	proc := process.New(&processElement, &testParallelGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -75,19 +71,15 @@ func TestParallelGateway(t *testing.T) {
 	}
 }
 
+var testParallelGatewayMtoN bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/parallel_gateway_m_n.bpmn", testdata, &testParallelGatewayMtoN)
+}
+
 func TestParallelGatewayMtoN(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/parallel_gateway_m_n.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testParallelGatewayMtoN.Processes())[0]
+	proc := process.New(&processElement, &testParallelGatewayMtoN)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -128,19 +120,15 @@ func TestParallelGatewayMtoN(t *testing.T) {
 	}
 }
 
+var testParallelGatewayNtoM bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/parallel_gateway_n_m.bpmn", testdata, &testParallelGatewayNtoM)
+}
+
 func TestParallelGatewayNtoM(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/parallel_gateway_n_m.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testParallelGatewayNtoM.Processes())[0]
+	proc := process.New(&processElement, &testParallelGatewayNtoM)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()
@@ -182,19 +170,15 @@ func TestParallelGatewayNtoM(t *testing.T) {
 	}
 }
 
+var testParallelGatewayIncompleteJoin bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/parallel_gateway_fork_incomplete_join.bpmn", testdata, &testParallelGatewayIncompleteJoin)
+}
+
 func TestParallelGatewayIncompleteJoin(t *testing.T) {
-	var testDoc bpmn.Definitions
-	var err error
-	src, err := testdata.ReadFile("testdata/parallel_gateway_fork_incomplete_join.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(src, &testDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
-	processElement := (*testDoc.Processes())[0]
-	proc := process.New(&processElement, &testDoc)
+	processElement := (*testParallelGatewayIncompleteJoin.Processes())[0]
+	proc := process.New(&processElement, &testParallelGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
 		err := instance.Run()

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -9,9 +9,9 @@
 package model
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/process"
 	"github.com/stretchr/testify/assert"
@@ -27,17 +27,13 @@ func exactId(s string) func(p *process.Process) bool {
 	}
 }
 
+var sampleDoc bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/sample.bpmn", testdata, &sampleDoc)
+}
+
 func TestFindProcess(t *testing.T) {
-	var sampleDoc bpmn.Definitions
-	var err error
-	sample, err := testdata.ReadFile("testdata/sample.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(sample, &sampleDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
 	model := New(&sampleDoc)
 	if proc, found := model.FindProcessBy(exactId("sample")); found {
 		if id, present := proc.Element.Id(); present {

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -9,27 +9,22 @@
 package process
 
 import (
-	"encoding/xml"
 	"testing"
 
+	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"github.com/stretchr/testify/assert"
 )
 
 var defaultDefinitions = bpmn.DefaultDefinitions()
 
-func TestExplicitInstantiation(t *testing.T) {
-	var sampleDoc bpmn.Definitions
-	var err error
-	sample, err := testdata.ReadFile("testdata/sample.bpmn")
-	if err != nil {
-		t.Fatalf("Can't read file: %v", err)
-	}
-	err = xml.Unmarshal(sample, &sampleDoc)
-	if err != nil {
-		t.Fatalf("XML unmarshalling error: %v", err)
-	}
+var sampleDoc bpmn.Definitions
 
+func init() {
+	internal.LoadTestFile("testdata/sample.bpmn", testdata, &sampleDoc)
+}
+
+func TestExplicitInstantiation(t *testing.T) {
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
 		process := New(proc.(*bpmn.Process), &defaultDefinitions)
 		instance, err := process.Instantiate()


### PR DESCRIPTION
Especially now that we run them 100 times each.

Solution: deserialize BPMN documents in tests only once