### PR TITLE
Problem: absence of data flow

### DIFF
--- a/pkg/bpmn/schema_generated.go
+++ b/pkg/bpmn/schema_generated.go
@@ -698,7 +698,6 @@ type Activity struct {
 	ResourceRoleField                     []ResourceRole                    `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL resourceRole"`
 	MultiInstanceLoopCharacteristicsField *MultiInstanceLoopCharacteristics `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL multiInstanceLoopCharacteristics"`
 	StandardLoopCharacteristicsField      *StandardLoopCharacteristics      `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL standardLoopCharacteristics"`
-	TextPayloadField                      string                            `xml:",chardata"`
 }
 
 var defaultActivityIsForCompensationField bool = false
@@ -740,13 +739,8 @@ type ActivityInterface interface {
 	SetResourceRoles(value []ResourceRole)
 	SetMultiInstanceLoopCharacteristics(value *MultiInstanceLoopCharacteristics)
 	SetStandardLoopCharacteristics(value *StandardLoopCharacteristics)
-
-	TextPayload() *string
 }
 
-func (t *Activity) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *Activity) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -999,7 +993,6 @@ func (t *AdHocSubProcess) SetCompletionCondition(value *AnExpression) {
 
 type Artifact struct {
 	BaseElement
-	TextPayloadField string `xml:",chardata"`
 }
 
 func DefaultArtifact() Artifact {
@@ -1011,13 +1004,8 @@ func DefaultArtifact() Artifact {
 type ArtifactInterface interface {
 	Element
 	BaseElementInterface
-
-	TextPayload() *string
 }
 
-func (t *Artifact) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *Artifact) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -1214,7 +1202,6 @@ type BaseElement struct {
 	IdField                *Id                `xml:"id,attr"`
 	DocumentationField     []Documentation    `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL documentation"`
 	ExtensionElementsField *ExtensionElements `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL extensionElements"`
-	TextPayloadField       string             `xml:",chardata"`
 }
 
 func DefaultBaseElement() BaseElement {
@@ -1229,13 +1216,8 @@ type BaseElementInterface interface {
 	SetId(value *Id)
 	SetDocumentations(value []Documentation)
 	SetExtensionElements(value *ExtensionElements)
-
-	TextPayload() *string
 }
 
-func (t *BaseElement) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *BaseElement) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -1292,7 +1274,6 @@ type BaseElementWithMixedContent struct {
 	IdField                *Id                `xml:"id,attr"`
 	DocumentationField     []Documentation    `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL documentation"`
 	ExtensionElementsField *ExtensionElements `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL extensionElements"`
-	TextPayloadField       string             `xml:",chardata"`
 }
 
 func DefaultBaseElementWithMixedContent() BaseElementWithMixedContent {
@@ -1307,13 +1288,8 @@ type BaseElementWithMixedContentInterface interface {
 	SetId(value *Id)
 	SetDocumentations(value []Documentation)
 	SetExtensionElements(value *ExtensionElements)
-
-	TextPayload() *string
 }
 
-func (t *BaseElementWithMixedContent) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *BaseElementWithMixedContent) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -1814,7 +1790,6 @@ type CatchEvent struct {
 	TerminateEventDefinitionField   []TerminateEventDefinition   `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL terminateEventDefinition"`
 	TimerEventDefinitionField       []TimerEventDefinition       `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL timerEventDefinition"`
 	EventDefinitionRefField         []QName                      `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL eventDefinitionRef"`
-	TextPayloadField                string                       `xml:",chardata"`
 }
 
 var defaultCatchEventParallelMultipleField bool = false
@@ -1860,13 +1835,8 @@ type CatchEventInterface interface {
 	SetTerminateEventDefinitions(value []TerminateEventDefinition)
 	SetTimerEventDefinitions(value []TimerEventDefinition)
 	SetEventDefinitionRefs(value []QName)
-
-	TextPayload() *string
 }
 
-func (t *CatchEvent) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *CatchEvent) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -2903,7 +2873,6 @@ type ChoreographyActivity struct {
 	LoopTypeField                 *ChoreographyLoopType `xml:"loopType,attr"`
 	ParticipantRefField           []QName               `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL participantRef"`
 	CorrelationKeyField           []CorrelationKey      `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL correlationKey"`
-	TextPayloadField              string                `xml:",chardata"`
 }
 
 var defaultChoreographyActivityLoopTypeField ChoreographyLoopType = "None"
@@ -2926,13 +2895,8 @@ type ChoreographyActivityInterface interface {
 	SetLoopType(value *ChoreographyLoopType)
 	SetParticipantRefs(value []QName)
 	SetCorrelationKeys(value []CorrelationKey)
-
-	TextPayload() *string
 }
 
-func (t *ChoreographyActivity) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *ChoreographyActivity) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -3778,7 +3742,6 @@ type ConversationNode struct {
 	ParticipantRefField []QName          `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL participantRef"`
 	MessageFlowRefField []QName          `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL messageFlowRef"`
 	CorrelationKeyField []CorrelationKey `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL correlationKey"`
-	TextPayloadField    string           `xml:",chardata"`
 }
 
 func DefaultConversationNode() ConversationNode {
@@ -3798,13 +3761,8 @@ type ConversationNodeInterface interface {
 	SetParticipantRefs(value []QName)
 	SetMessageFlowRefs(value []QName)
 	SetCorrelationKeys(value []CorrelationKey)
-
-	TextPayload() *string
 }
 
-func (t *ConversationNode) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *ConversationNode) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -4275,34 +4233,28 @@ func (t *DataAssociation) SetAssignments(value []Assignment) {
 }
 
 type DataInput struct {
-	BaseElement
-	NameField           *string    `xml:"name,attr"`
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	IsCollectionField   *bool      `xml:"isCollection,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAwareElement
+	NameField         *string `xml:"name,attr"`
+	IsCollectionField *bool   `xml:"isCollection,attr"`
+	TextPayloadField  string  `xml:",chardata"`
 }
 
 var defaultDataInputIsCollectionField bool = false
 
 func DefaultDataInput() DataInput {
 	return DataInput{
-		BaseElement:       DefaultBaseElement(),
+		ItemAwareElement:  DefaultItemAwareElement(),
 		IsCollectionField: &defaultDataInputIsCollectionField,
 	}
 }
 
 type DataInputInterface interface {
 	Element
-	BaseElementInterface
+	ItemAwareElementInterface
 	Name() (result *string, present bool)
-	ItemSubjectRef() (result *QName, present bool)
 	IsCollection() (result bool)
-	DataState() (result *DataState, present bool)
 	SetName(value *string)
-	SetItemSubjectRef(value *QName)
 	SetIsCollection(value *bool)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4319,14 +4271,8 @@ func (t *DataInput) FindBy(f ElementPredicate) (result Element, found bool) {
 		found = true
 		return
 	}
-	if result, found = t.BaseElement.FindBy(f); found {
+	if result, found = t.ItemAwareElement.FindBy(f); found {
 		return
-	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
 	}
 
 	return
@@ -4341,16 +4287,6 @@ func (t *DataInput) Name() (result *string, present bool) {
 func (t *DataInput) SetName(value *string) {
 	t.NameField = value
 }
-func (t *DataInput) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataInput) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
-}
 func (t *DataInput) IsCollection() (result bool) {
 	if t.IsCollectionField == nil {
 		result = defaultDataInputIsCollectionField
@@ -4361,16 +4297,6 @@ func (t *DataInput) IsCollection() (result bool) {
 }
 func (t *DataInput) SetIsCollection(value *bool) {
 	t.IsCollectionField = value
-}
-func (t *DataInput) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataInput) SetDataState(value *DataState) {
-	t.DataStateField = value
 }
 
 type DataInputAssociation struct {
@@ -4412,10 +4338,9 @@ func (t *DataInputAssociation) FindBy(f ElementPredicate) (result Element, found
 
 type DataObject struct {
 	FlowElement
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	IsCollectionField   *bool      `xml:"isCollection,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAware
+	IsCollectionField *bool  `xml:"isCollection,attr"`
+	TextPayloadField  string `xml:",chardata"`
 }
 
 var defaultDataObjectIsCollectionField bool = false
@@ -4423,6 +4348,7 @@ var defaultDataObjectIsCollectionField bool = false
 func DefaultDataObject() DataObject {
 	return DataObject{
 		FlowElement:       DefaultFlowElement(),
+		ItemAware:         DefaultItemAware(),
 		IsCollectionField: &defaultDataObjectIsCollectionField,
 	}
 }
@@ -4430,12 +4356,9 @@ func DefaultDataObject() DataObject {
 type DataObjectInterface interface {
 	Element
 	FlowElementInterface
-	ItemSubjectRef() (result *QName, present bool)
+	ItemAwareInterface
 	IsCollection() (result bool)
-	DataState() (result *DataState, present bool)
-	SetItemSubjectRef(value *QName)
 	SetIsCollection(value *bool)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4455,24 +4378,11 @@ func (t *DataObject) FindBy(f ElementPredicate) (result Element, found bool) {
 	if result, found = t.FlowElement.FindBy(f); found {
 		return
 	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
+	if result, found = t.ItemAware.FindBy(f); found {
+		return
 	}
 
 	return
-}
-func (t *DataObject) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataObject) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
 }
 func (t *DataObject) IsCollection() (result bool) {
 	if t.IsCollectionField == nil {
@@ -4485,40 +4395,27 @@ func (t *DataObject) IsCollection() (result bool) {
 func (t *DataObject) SetIsCollection(value *bool) {
 	t.IsCollectionField = value
 }
-func (t *DataObject) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataObject) SetDataState(value *DataState) {
-	t.DataStateField = value
-}
 
 type DataObjectReference struct {
 	FlowElement
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	DataObjectRefField  *IdRef     `xml:"dataObjectRef,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAware
+	DataObjectRefField *IdRef `xml:"dataObjectRef,attr"`
+	TextPayloadField   string `xml:",chardata"`
 }
 
 func DefaultDataObjectReference() DataObjectReference {
 	return DataObjectReference{
 		FlowElement: DefaultFlowElement(),
+		ItemAware:   DefaultItemAware(),
 	}
 }
 
 type DataObjectReferenceInterface interface {
 	Element
 	FlowElementInterface
-	ItemSubjectRef() (result *QName, present bool)
+	ItemAwareInterface
 	DataObjectRef() (result *IdRef, present bool)
-	DataState() (result *DataState, present bool)
-	SetItemSubjectRef(value *QName)
 	SetDataObjectRef(value *IdRef)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4538,24 +4435,11 @@ func (t *DataObjectReference) FindBy(f ElementPredicate) (result Element, found 
 	if result, found = t.FlowElement.FindBy(f); found {
 		return
 	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
+	if result, found = t.ItemAware.FindBy(f); found {
+		return
 	}
 
 	return
-}
-func (t *DataObjectReference) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataObjectReference) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
 }
 func (t *DataObjectReference) DataObjectRef() (result *IdRef, present bool) {
 	if t.DataObjectRefField != nil {
@@ -4567,46 +4451,30 @@ func (t *DataObjectReference) DataObjectRef() (result *IdRef, present bool) {
 func (t *DataObjectReference) SetDataObjectRef(value *IdRef) {
 	t.DataObjectRefField = value
 }
-func (t *DataObjectReference) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataObjectReference) SetDataState(value *DataState) {
-	t.DataStateField = value
-}
 
 type DataOutput struct {
-	BaseElement
-	NameField           *string    `xml:"name,attr"`
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	IsCollectionField   *bool      `xml:"isCollection,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAwareElement
+	NameField         *string `xml:"name,attr"`
+	IsCollectionField *bool   `xml:"isCollection,attr"`
+	TextPayloadField  string  `xml:",chardata"`
 }
 
 var defaultDataOutputIsCollectionField bool = false
 
 func DefaultDataOutput() DataOutput {
 	return DataOutput{
-		BaseElement:       DefaultBaseElement(),
+		ItemAwareElement:  DefaultItemAwareElement(),
 		IsCollectionField: &defaultDataOutputIsCollectionField,
 	}
 }
 
 type DataOutputInterface interface {
 	Element
-	BaseElementInterface
+	ItemAwareElementInterface
 	Name() (result *string, present bool)
-	ItemSubjectRef() (result *QName, present bool)
 	IsCollection() (result bool)
-	DataState() (result *DataState, present bool)
 	SetName(value *string)
-	SetItemSubjectRef(value *QName)
 	SetIsCollection(value *bool)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4623,14 +4491,8 @@ func (t *DataOutput) FindBy(f ElementPredicate) (result Element, found bool) {
 		found = true
 		return
 	}
-	if result, found = t.BaseElement.FindBy(f); found {
+	if result, found = t.ItemAwareElement.FindBy(f); found {
 		return
-	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
 	}
 
 	return
@@ -4645,16 +4507,6 @@ func (t *DataOutput) Name() (result *string, present bool) {
 func (t *DataOutput) SetName(value *string) {
 	t.NameField = value
 }
-func (t *DataOutput) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataOutput) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
-}
 func (t *DataOutput) IsCollection() (result bool) {
 	if t.IsCollectionField == nil {
 		result = defaultDataOutputIsCollectionField
@@ -4665,16 +4517,6 @@ func (t *DataOutput) IsCollection() (result bool) {
 }
 func (t *DataOutput) SetIsCollection(value *bool) {
 	t.IsCollectionField = value
-}
-func (t *DataOutput) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataOutput) SetDataState(value *DataState) {
-	t.DataStateField = value
 }
 
 type DataOutputAssociation struct {
@@ -4766,12 +4608,11 @@ func (t *DataState) SetName(value *string) {
 
 type DataStore struct {
 	RootElement
-	NameField           *string    `xml:"name,attr"`
-	CapacityField       *big.Int   `xml:"capacity,attr"`
-	IsUnlimitedField    *bool      `xml:"isUnlimited,attr"`
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAware
+	NameField        *string  `xml:"name,attr"`
+	CapacityField    *big.Int `xml:"capacity,attr"`
+	IsUnlimitedField *bool    `xml:"isUnlimited,attr"`
+	TextPayloadField string   `xml:",chardata"`
 }
 
 var defaultDataStoreIsUnlimitedField bool = true
@@ -4779,6 +4620,7 @@ var defaultDataStoreIsUnlimitedField bool = true
 func DefaultDataStore() DataStore {
 	return DataStore{
 		RootElement:      DefaultRootElement(),
+		ItemAware:        DefaultItemAware(),
 		IsUnlimitedField: &defaultDataStoreIsUnlimitedField,
 	}
 }
@@ -4786,16 +4628,13 @@ func DefaultDataStore() DataStore {
 type DataStoreInterface interface {
 	Element
 	RootElementInterface
+	ItemAwareInterface
 	Name() (result *string, present bool)
 	Capacity() (result *big.Int, present bool)
 	IsUnlimited() (result bool)
-	ItemSubjectRef() (result *QName, present bool)
-	DataState() (result *DataState, present bool)
 	SetName(value *string)
 	SetCapacity(value *big.Int)
 	SetIsUnlimited(value *bool)
-	SetItemSubjectRef(value *QName)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4815,11 +4654,8 @@ func (t *DataStore) FindBy(f ElementPredicate) (result Element, found bool) {
 	if result, found = t.RootElement.FindBy(f); found {
 		return
 	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
+	if result, found = t.ItemAware.FindBy(f); found {
+		return
 	}
 
 	return
@@ -4855,50 +4691,27 @@ func (t *DataStore) IsUnlimited() (result bool) {
 func (t *DataStore) SetIsUnlimited(value *bool) {
 	t.IsUnlimitedField = value
 }
-func (t *DataStore) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataStore) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
-}
-func (t *DataStore) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataStore) SetDataState(value *DataState) {
-	t.DataStateField = value
-}
 
 type DataStoreReference struct {
 	FlowElement
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	DataStoreRefField   *QName     `xml:"dataStoreRef,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAware
+	DataStoreRefField *QName `xml:"dataStoreRef,attr"`
+	TextPayloadField  string `xml:",chardata"`
 }
 
 func DefaultDataStoreReference() DataStoreReference {
 	return DataStoreReference{
 		FlowElement: DefaultFlowElement(),
+		ItemAware:   DefaultItemAware(),
 	}
 }
 
 type DataStoreReferenceInterface interface {
 	Element
 	FlowElementInterface
-	ItemSubjectRef() (result *QName, present bool)
+	ItemAwareInterface
 	DataStoreRef() (result *QName, present bool)
-	DataState() (result *DataState, present bool)
-	SetItemSubjectRef(value *QName)
 	SetDataStoreRef(value *QName)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -4918,24 +4731,11 @@ func (t *DataStoreReference) FindBy(f ElementPredicate) (result Element, found b
 	if result, found = t.FlowElement.FindBy(f); found {
 		return
 	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
+	if result, found = t.ItemAware.FindBy(f); found {
+		return
 	}
 
 	return
-}
-func (t *DataStoreReference) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *DataStoreReference) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
 }
 func (t *DataStoreReference) DataStoreRef() (result *QName, present bool) {
 	if t.DataStoreRefField != nil {
@@ -4946,16 +4746,6 @@ func (t *DataStoreReference) DataStoreRef() (result *QName, present bool) {
 }
 func (t *DataStoreReference) SetDataStoreRef(value *QName) {
 	t.DataStoreRefField = value
-}
-func (t *DataStoreReference) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *DataStoreReference) SetDataState(value *DataState) {
-	t.DataStateField = value
 }
 
 type Documentation struct {
@@ -5347,8 +5137,7 @@ func (t *EscalationEventDefinition) SetEscalationRef(value *QName) {
 
 type Event struct {
 	FlowNode
-	PropertyField    []Property `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL property"`
-	TextPayloadField string     `xml:",chardata"`
+	PropertyField []Property `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL property"`
 }
 
 func DefaultEvent() Event {
@@ -5362,13 +5151,8 @@ type EventInterface interface {
 	FlowNodeInterface
 	Properties() (result *[]Property)
 	SetProperties(value []Property)
-
-	TextPayload() *string
 }
 
-func (t *Event) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *Event) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -5470,7 +5254,6 @@ func (t *EventBasedGateway) SetEventGatewayType(value *EventBasedGatewayType) {
 
 type EventDefinition struct {
 	RootElement
-	TextPayloadField string `xml:",chardata"`
 }
 
 func DefaultEventDefinition() EventDefinition {
@@ -5482,13 +5265,8 @@ func DefaultEventDefinition() EventDefinition {
 type EventDefinitionInterface interface {
 	Element
 	RootElementInterface
-
-	TextPayload() *string
 }
 
-func (t *EventDefinition) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *EventDefinition) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -5705,7 +5483,6 @@ type FlowElement struct {
 	AuditingField         *Auditing   `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL auditing"`
 	MonitoringField       *Monitoring `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL monitoring"`
 	CategoryValueRefField []QName     `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL categoryValueRef"`
-	TextPayloadField      string      `xml:",chardata"`
 }
 
 func DefaultFlowElement() FlowElement {
@@ -5725,13 +5502,8 @@ type FlowElementInterface interface {
 	SetAuditing(value *Auditing)
 	SetMonitoring(value *Monitoring)
 	SetCategoryValueRefs(value []QName)
-
-	TextPayload() *string
 }
 
-func (t *FlowElement) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *FlowElement) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -5799,9 +5571,8 @@ func (t *FlowElement) SetCategoryValueRefs(value []QName) {
 
 type FlowNode struct {
 	FlowElement
-	IncomingField    []QName `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL incoming"`
-	OutgoingField    []QName `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL outgoing"`
-	TextPayloadField string  `xml:",chardata"`
+	IncomingField []QName `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL incoming"`
+	OutgoingField []QName `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL outgoing"`
 }
 
 func DefaultFlowNode() FlowNode {
@@ -5817,13 +5588,8 @@ type FlowNodeInterface interface {
 	Outgoings() (result *[]QName)
 	SetIncomings(value []QName)
 	SetOutgoings(value []QName)
-
-	TextPayload() *string
 }
 
-func (t *FlowNode) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *FlowNode) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -6921,6 +6687,99 @@ func (t *InputOutputSpecification) SetOutputSets(value []OutputSet) {
 	t.OutputSetField = value
 }
 
+type ItemAware struct {
+	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
+	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
+}
+
+func DefaultItemAware() ItemAware {
+	return ItemAware{}
+}
+
+type ItemAwareInterface interface {
+	Element
+	ItemSubjectRef() (result *QName, present bool)
+	DataState() (result *DataState, present bool)
+	SetItemSubjectRef(value *QName)
+	SetDataState(value *DataState)
+}
+
+func (t *ItemAware) FindBy(f ElementPredicate) (result Element, found bool) {
+	if t == nil {
+		return
+	}
+	if f(t) {
+		result = t
+		found = true
+		return
+	}
+
+	if value := t.DataStateField; value != nil {
+		if result, found = value.FindBy(f); found {
+			return
+		}
+	}
+
+	return
+}
+func (t *ItemAware) ItemSubjectRef() (result *QName, present bool) {
+	if t.ItemSubjectRefField != nil {
+		present = true
+	}
+	result = t.ItemSubjectRefField
+	return
+}
+func (t *ItemAware) SetItemSubjectRef(value *QName) {
+	t.ItemSubjectRefField = value
+}
+func (t *ItemAware) DataState() (result *DataState, present bool) {
+	if t.DataStateField != nil {
+		present = true
+	}
+	result = t.DataStateField
+	return
+}
+func (t *ItemAware) SetDataState(value *DataState) {
+	t.DataStateField = value
+}
+
+type ItemAwareElement struct {
+	BaseElement
+	ItemAware
+}
+
+func DefaultItemAwareElement() ItemAwareElement {
+	return ItemAwareElement{
+		BaseElement: DefaultBaseElement(),
+		ItemAware:   DefaultItemAware(),
+	}
+}
+
+type ItemAwareElementInterface interface {
+	Element
+	BaseElementInterface
+	ItemAwareInterface
+}
+
+func (t *ItemAwareElement) FindBy(f ElementPredicate) (result Element, found bool) {
+	if t == nil {
+		return
+	}
+	if f(t) {
+		result = t
+		found = true
+		return
+	}
+	if result, found = t.BaseElement.FindBy(f); found {
+		return
+	}
+	if result, found = t.ItemAware.FindBy(f); found {
+		return
+	}
+
+	return
+}
+
 type ItemDefinition struct {
 	RootElement
 	StructureRefField *QName    `xml:"structureRef,attr"`
@@ -7253,7 +7112,6 @@ func (t *LinkEventDefinition) SetTarget(value *QName) {
 
 type LoopCharacteristics struct {
 	BaseElement
-	TextPayloadField string `xml:",chardata"`
 }
 
 func DefaultLoopCharacteristics() LoopCharacteristics {
@@ -7265,13 +7123,8 @@ func DefaultLoopCharacteristics() LoopCharacteristics {
 type LoopCharacteristicsInterface interface {
 	Element
 	BaseElementInterface
-
-	TextPayload() *string
 }
 
-func (t *LoopCharacteristics) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *LoopCharacteristics) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -9386,28 +9239,22 @@ func (t *Process) SetSupportses(value []QName) {
 }
 
 type Property struct {
-	BaseElement
-	NameField           *string    `xml:"name,attr"`
-	ItemSubjectRefField *QName     `xml:"itemSubjectRef,attr"`
-	DataStateField      *DataState `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL dataState"`
-	TextPayloadField    string     `xml:",chardata"`
+	ItemAwareElement
+	NameField        *string `xml:"name,attr"`
+	TextPayloadField string  `xml:",chardata"`
 }
 
 func DefaultProperty() Property {
 	return Property{
-		BaseElement: DefaultBaseElement(),
+		ItemAwareElement: DefaultItemAwareElement(),
 	}
 }
 
 type PropertyInterface interface {
 	Element
-	BaseElementInterface
+	ItemAwareElementInterface
 	Name() (result *string, present bool)
-	ItemSubjectRef() (result *QName, present bool)
-	DataState() (result *DataState, present bool)
 	SetName(value *string)
-	SetItemSubjectRef(value *QName)
-	SetDataState(value *DataState)
 
 	TextPayload() *string
 }
@@ -9424,14 +9271,8 @@ func (t *Property) FindBy(f ElementPredicate) (result Element, found bool) {
 		found = true
 		return
 	}
-	if result, found = t.BaseElement.FindBy(f); found {
+	if result, found = t.ItemAwareElement.FindBy(f); found {
 		return
-	}
-
-	if value := t.DataStateField; value != nil {
-		if result, found = value.FindBy(f); found {
-			return
-		}
 	}
 
 	return
@@ -9445,26 +9286,6 @@ func (t *Property) Name() (result *string, present bool) {
 }
 func (t *Property) SetName(value *string) {
 	t.NameField = value
-}
-func (t *Property) ItemSubjectRef() (result *QName, present bool) {
-	if t.ItemSubjectRefField != nil {
-		present = true
-	}
-	result = t.ItemSubjectRefField
-	return
-}
-func (t *Property) SetItemSubjectRef(value *QName) {
-	t.ItemSubjectRefField = value
-}
-func (t *Property) DataState() (result *DataState, present bool) {
-	if t.DataStateField != nil {
-		present = true
-	}
-	result = t.DataStateField
-	return
-}
-func (t *Property) SetDataState(value *DataState) {
-	t.DataStateField = value
 }
 
 type ReceiveTask struct {
@@ -10027,7 +9848,6 @@ func (t *ResourceRole) SetResourceAssignmentExpression(value *ResourceAssignment
 
 type RootElement struct {
 	BaseElement
-	TextPayloadField string `xml:",chardata"`
 }
 
 func DefaultRootElement() RootElement {
@@ -10039,13 +9859,8 @@ func DefaultRootElement() RootElement {
 type RootElementInterface interface {
 	Element
 	BaseElementInterface
-
-	TextPayload() *string
 }
 
-func (t *RootElement) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *RootElement) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return
@@ -12430,7 +12245,6 @@ type ThrowEvent struct {
 	TerminateEventDefinitionField   []TerminateEventDefinition   `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL terminateEventDefinition"`
 	TimerEventDefinitionField       []TimerEventDefinition       `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL timerEventDefinition"`
 	EventDefinitionRefField         []QName                      `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL eventDefinitionRef"`
-	TextPayloadField                string                       `xml:",chardata"`
 }
 
 func DefaultThrowEvent() ThrowEvent {
@@ -12471,13 +12285,8 @@ type ThrowEventInterface interface {
 	SetTerminateEventDefinitions(value []TerminateEventDefinition)
 	SetTimerEventDefinitions(value []TimerEventDefinition)
 	SetEventDefinitionRefs(value []QName)
-
-	TextPayload() *string
 }
 
-func (t *ThrowEvent) TextPayload() *string {
-	return &t.TextPayloadField
-}
 func (t *ThrowEvent) FindBy(f ElementPredicate) (result Element, found bool) {
 	if t == nil {
 		return

--- a/pkg/bpmn/schema_generated_test.go
+++ b/pkg/bpmn/schema_generated_test.go
@@ -422,6 +422,16 @@ func TestInputOutputSpecificationInterface(t *testing.T) {
 	var _ InputOutputSpecificationInterface = &InputOutputSpecification{}
 
 }
+func TestItemAwareInterface(t *testing.T) {
+	// won't compile if the interaces are not implemented
+	var _ ItemAwareInterface = &ItemAware{}
+
+}
+func TestItemAwareElementInterface(t *testing.T) {
+	// won't compile if the interaces are not implemented
+	var _ ItemAwareElementInterface = &ItemAwareElement{}
+
+}
 func TestItemDefinitionInterface(t *testing.T) {
 	// won't compile if the interaces are not implemented
 	var _ ItemDefinitionInterface = &ItemDefinition{}

--- a/pkg/data/container.go
+++ b/pkg/data/container.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package data
+
+import (
+	"bpxe.org/pkg/bpmn"
+)
+
+type runnerMessage interface {
+	implementsRunnerMessage()
+}
+
+type getMessage struct {
+	channel chan Item
+}
+
+func (g getMessage) implementsRunnerMessage() {}
+
+type putMessage struct {
+	item Item
+}
+
+func (p putMessage) implementsRunnerMessage() {}
+
+type Container struct {
+	bpmn.ItemAwareInterface
+	runnerChannel chan runnerMessage
+	item          Item
+}
+
+func NewContainer(itemAware bpmn.ItemAwareInterface) *Container {
+	container := &Container{
+		ItemAwareInterface: itemAware,
+		runnerChannel:      make(chan runnerMessage, 1),
+	}
+	go container.run()
+	return container
+}
+
+func (c *Container) Unavailable() bool {
+	return false
+}
+
+func (c *Container) run() {
+	for {
+		msg := <-c.runnerChannel
+		switch msg := msg.(type) {
+		case getMessage:
+			msg.channel <- c.item
+		case putMessage:
+			c.item = msg.item
+		}
+	}
+}
+
+func (c *Container) Get() <-chan Item {
+	ch := make(chan Item)
+	c.runnerChannel <- getMessage{channel: ch}
+	return ch
+}
+
+func (c *Container) Put(item Item) {
+	c.runnerChannel <- putMessage{item: item}
+}

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package data
+
+import (
+	"context"
+
+	"bpxe.org/pkg/bpmn"
+)
+
+// Item is an abstract interface for a piece of data
+type Item interface {
+}
+
+// IteratorStopper stops Collection iterator and releases resources
+// associated with it
+type IteratorStopper interface {
+	// Stop does the actual stopping
+	Stop()
+}
+
+type channelIteratorStopper struct {
+	ch chan struct{}
+}
+
+func makeChannelIteratorStopper() channelIteratorStopper {
+	return channelIteratorStopper{ch: make(chan struct{})}
+}
+
+func (c channelIteratorStopper) close() {
+	close(c.ch)
+}
+
+func (c channelIteratorStopper) Stop() {
+	c.ch <- struct{}{}
+}
+
+type Collection interface {
+	Item
+	// ItemIterator returns a channel that iterates over collection's
+	// items and an IteratorStopper that must be used if iterator was
+	// not exhausted, otherwise there'll be a memory leak in a form
+	// of a goroutine that does nothing.
+	//
+	// The iterator will also clean itself up and terminate upon
+	// context termination.
+	ItemIterator(ctx context.Context) (chan Item, IteratorStopper)
+}
+
+type SliceIterator []Item
+
+func (s *SliceIterator) ItemIterator(ctx context.Context) (items chan Item, stop IteratorStopper) {
+	items = make(chan Item)
+	stopper := makeChannelIteratorStopper()
+	stop = stopper
+	go func() {
+	loop:
+		for i := range *s {
+			select {
+			case <-ctx.Done():
+				break loop
+			case <-stopper.ch:
+				break loop
+			case items <- (*s)[i]:
+			}
+		}
+		close(items)
+		stopper.close()
+	}()
+	return
+}
+
+// ItemOrCollection will return nil if no items given,
+// the same item if only one item is given and SliceIterator
+// if more than one item is given. SliceIterator implements
+// Collection and, therefore, also implements Item.
+func ItemOrCollection(items ...Item) (item Item) {
+	switch len(items) {
+	case 0:
+	case 1:
+		item = items[0]
+	default:
+		item = SliceIterator(items)
+	}
+	return
+}
+
+// ItemAware provides basic interface of accessing data items
+type ItemAware interface {
+	// Unavailable returns true if the data item is an unavailable state
+	Unavailable() bool
+	// Get returns a channel that will eventually return the data item
+	//
+	// If item is in an unavailable state (see Unavailable),
+	// this channel will not send anything until the item becomes available
+	Get() <-chan Item
+	// Put sends a request to update the item
+	//
+	// If item is in an unavailable state (see Unavailable),
+	// the data will not update until the item becomes available
+	Put(Item)
+}
+
+// ItemAwareLocator interface describes a way to find ItemAware
+type ItemAwareLocator interface {
+	// FindItemAwareById finds ItemAware by its bpmn.Id
+	FindItemAwareById(id bpmn.IdRef) (itemAware ItemAware, found bool)
+	// FindItemAwareByName finds ItemAware by its name (where applicable)
+	FindItemAwareByName(name string) (itemAware ItemAware, found bool)
+}

--- a/pkg/data/data_test.go
+++ b/pkg/data/data_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package data
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSliceIterator_ItemIterator(t *testing.T) {
+	items := SliceIterator([]Item{1, "hello"})
+	ctx := context.Background()
+	iterator, _ := items.ItemIterator(ctx)
+	newItems := SliceIterator(make([]Item, 0, len(items)))
+	for e := range iterator {
+		newItems = append(newItems, e)
+	}
+	assert.Equal(t, items, newItems)
+}
+
+func TestSliceIterator_ItemIterator_Stopping(t *testing.T) {
+	items := SliceIterator([]Item{1, "hello"})
+	ctx := context.Background()
+	iterator, stopper := items.ItemIterator(ctx)
+	stopper.Stop()
+	value, ok := <-iterator
+	assert.Nil(t, value)
+	assert.False(t, ok)
+}
+
+func TestSliceIterator_ItemIterator_ContextDone(t *testing.T) {
+	items := SliceIterator([]Item{1, "hello"})
+	ctx, cancel := context.WithCancel(context.Background())
+	iterator, stop := items.ItemIterator(ctx)
+	cancel()
+
+	// Wait until stopper is closed. This is definitely not
+	// black box testing, but this essentially ensures
+	// the cancellation has been handled
+	stopper := stop.(channelIteratorStopper)
+	<-stopper.ch
+
+	value, ok := <-iterator
+	assert.Nil(t, value)
+	assert.False(t, ok)
+}

--- a/pkg/data/package.go
+++ b/pkg/data/package.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package data

--- a/pkg/data/xml.go
+++ b/pkg/data/xml.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package data
+
+type AsXML interface {
+	AsXML() []byte
+}
+
+type XMLSource []byte
+
+func (x XMLSource) AsXML() []byte {
+	return x
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -44,3 +44,12 @@ type RequirementExpectationError struct {
 func (e RequirementExpectationError) Error() string {
 	return fmt.Sprintf("Requirement expectation failed: expected %v, got %v", e.Expected, e.Actual)
 }
+
+type NotSupportedError struct {
+	What   string
+	Reason string
+}
+
+func (e NotSupportedError) Error() string {
+	return fmt.Sprintf("%s is not supported because %s", e.What, e.Reason)
+}

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -10,6 +10,7 @@ package event
 
 import (
 	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/data"
 )
 
 type ProcessEvent interface {
@@ -57,14 +58,15 @@ func (ev NoneEvent) MatchesEventInstance(instance Instance) bool {
 // Signal event
 type SignalEvent struct {
 	signalRef string
+	item      data.Item
 }
 
-func MakeSignalEvent(signalRef string) SignalEvent {
-	return SignalEvent{signalRef: signalRef}
+func MakeSignalEvent(signalRef string, items ...data.Item) SignalEvent {
+	return SignalEvent{signalRef: signalRef, item: data.ItemOrCollection(items)}
 }
 
-func NewSignalEvent(signalRef string) *SignalEvent {
-	event := MakeSignalEvent(signalRef)
+func NewSignalEvent(signalRef string, items ...data.Item) *SignalEvent {
+	event := MakeSignalEvent(signalRef, items)
 	return &event
 }
 
@@ -142,17 +144,19 @@ func (ev *CompensationEvent) ActivityRef() *string {
 type MessageEvent struct {
 	messageRef   string
 	operationRef *string
+	item         data.Item
 }
 
-func MakeMessageEvent(messageRef string, operationRef *string) MessageEvent {
+func MakeMessageEvent(messageRef string, operationRef *string, items ...data.Item) MessageEvent {
 	return MessageEvent{
 		messageRef:   messageRef,
 		operationRef: operationRef,
+		item:         data.ItemOrCollection(items),
 	}
 }
 
-func NewMessageEvent(messageRef string, operationRef *string) *MessageEvent {
-	event := MakeMessageEvent(messageRef, operationRef)
+func NewMessageEvent(messageRef string, operationRef *string, items ...data.Item) *MessageEvent {
+	event := MakeMessageEvent(messageRef, operationRef, items...)
 	return &event
 }
 
@@ -201,10 +205,11 @@ func (ev *MessageEvent) OperationRef() (result *string, present bool) {
 // Escalation event
 type EscalationEvent struct {
 	escalationRef string
+	item          data.Item
 }
 
-func MakeEscalationEvent(escalationRef string) EscalationEvent {
-	return EscalationEvent{escalationRef: escalationRef}
+func MakeEscalationEvent(escalationRef string, items ...data.Item) EscalationEvent {
+	return EscalationEvent{escalationRef: escalationRef, item: data.ItemOrCollection(items)}
 }
 
 func (ev *EscalationEvent) MatchesEventInstance(instance Instance) bool {
@@ -300,10 +305,11 @@ func (ev *LinkEvent) Target() (result *string, present bool) {
 // Error event
 type ErrorEvent struct {
 	errorRef string
+	item     data.Item
 }
 
-func MakeErrorEvent(errorRef string) ErrorEvent {
-	return ErrorEvent{errorRef: errorRef}
+func MakeErrorEvent(errorRef string, items ...data.Item) ErrorEvent {
+	return ErrorEvent{errorRef: errorRef, item: data.ItemOrCollection(items)}
 }
 
 func (ev *ErrorEvent) MatchesEventInstance(instance Instance) bool {

--- a/pkg/expression/engine.go
+++ b/pkg/expression/engine.go
@@ -8,6 +8,10 @@
 
 package expression
 
+import (
+	"bpxe.org/pkg/data"
+)
+
 type Compiler interface {
 	CompileExpression(source string) (CompiledExpression, error)
 }
@@ -23,4 +27,5 @@ type Result interface{}
 type Engine interface {
 	Compiler
 	Evaluator
+	SetItemAwareLocator(itemAwareLocator data.ItemAwareLocator)
 }

--- a/pkg/expression/expr_test.go
+++ b/pkg/expression/expr_test.go
@@ -11,6 +11,7 @@ package expression
 import (
 	"testing"
 
+	"bpxe.org/pkg/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +22,21 @@ func TestExpr(t *testing.T) {
 	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{
 		"a": 2,
 	})
+	assert.Nil(t, err)
+	assert.True(t, result.(bool))
+}
+
+func TestExpr_getDataObject(t *testing.T) {
+	var engine = NewExpr()
+	container := data.NewContainer(nil)
+	container.Put(1)
+	var objs dataObjects = map[string]data.ItemAware{
+		"dataObject": container,
+	}
+	engine.SetItemAwareLocator(objs)
+	compiled, err := engine.CompileExpression("getDataObject('dataObject') > 0")
+	assert.Nil(t, err)
+	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{})
 	assert.Nil(t, err)
 	assert.True(t, result.(bool))
 }

--- a/pkg/expression/xpath.go
+++ b/pkg/expression/xpath.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"reflect"
 
+	"bpxe.org/pkg/data"
 	"bpxe.org/pkg/errors"
 	"github.com/ChrisTrenkamp/xsel/exec"
 	"github.com/ChrisTrenkamp/xsel/grammar"
@@ -23,7 +24,13 @@ import (
 // XPath language engine
 //
 // Implementation details and limitations as per https://github.com/antchfx/xpath
-type XPath struct{}
+type XPath struct {
+	itemAwareLocator data.ItemAwareLocator
+}
+
+func (engine *XPath) SetItemAwareLocator(itemAwareLocator data.ItemAwareLocator) {
+	engine.itemAwareLocator = itemAwareLocator
+}
 
 func MakeXPath() XPath {
 	return XPath{}
@@ -43,7 +50,7 @@ func (engine *XPath) CompileExpression(source string) (result CompiledExpression
 }
 
 func (engine *XPath) EvaluateExpression(e CompiledExpression,
-	data interface{},
+	datum interface{},
 ) (result Result, err error) {
 	if expression, ok := e.(*grammar.Grammar); ok {
 		// Here, in order to save some prototyping type,
@@ -54,29 +61,38 @@ func (engine *XPath) EvaluateExpression(e CompiledExpression,
 		// over `interface{}` should be developed to optimize this path.
 
 		var serialized []byte
-		serialized, err = anyxml.Xml(data)
+		serialized, err = anyxml.Xml(datum)
 		if err != nil {
 			result = nil
 			return
 		}
 		p := parser.ReadXml(bytes.NewBuffer(serialized))
+
+		contextSettings := func(c *exec.ContextSettings) {
+			if engine.itemAwareLocator != nil {
+				c.FunctionLibrary[exec.Name("", "getDataObject")] = engine.getDataObject()
+			}
+		}
+
 		var cursor store.Cursor
 		cursor, err = store.CreateInMemory(p)
 		if err != nil {
 			return
 		}
 		var res exec.Result
-		res, err = exec.Exec(cursor, expression)
+		res, err = exec.Exec(cursor, expression, contextSettings)
 		if err != nil {
 			return
 		}
-		switch res := res.(type) {
+		switch r := res.(type) {
 		case exec.String:
-			result = res.String()
+			result = r.String()
 		case exec.Bool:
-			result = res.Bool()
+			result = r.Bool()
 		case exec.Number:
-			result = res.Number()
+			result = r.Number()
+		case exec.NodeSet:
+			result = r
 		}
 	} else {
 		err = errors.InvalidArgumentError{
@@ -85,4 +101,53 @@ func (engine *XPath) EvaluateExpression(e CompiledExpression,
 		}
 	}
 	return
+}
+
+var asXMLType = reflect.TypeOf(new(data.AsXML)).Elem()
+
+func (engine *XPath) getDataObject() func(context exec.Context, args ...exec.Result) (exec.Result, error) {
+	return func(context exec.Context, args ...exec.Result) (exec.Result, error) {
+		var name string
+		switch len(args) {
+		case 0:
+			return nil, errors.InvalidArgumentError{Expected: "at least one argument", Actual: "none"}
+		case 2:
+			return nil, errors.NotSupportedError{
+				What:   "two-argument getDataObject",
+				Reason: "BPXE doesn't support sub-processes yet",
+			}
+		case 1:
+			name = args[0].String()
+		}
+		itemAware, found := engine.itemAwareLocator.FindItemAwareByName(name)
+		if !found {
+			return exec.NodeSet{}, nil
+		}
+		item := <-itemAware.Get()
+		switch item := item.(type) {
+		case string:
+			return exec.String(item), nil
+		case float64:
+			return exec.Number(item), nil
+		case bool:
+			return exec.Bool(item), nil
+		default:
+			// Until we have own data type to represent XML nodes, we'll piggy-back
+			// on xsel's parser and datum.AsXML interface. This is not very efficient,
+			// but should do for now
+			if reflect.TypeOf(item).Implements(asXMLType) {
+				p := parser.ReadXml(bytes.NewReader(item.(data.AsXML).AsXML()))
+				cursor, err := store.CreateInMemory(p)
+				if err != nil {
+					return nil, err
+				}
+				return exec.NodeSet{cursor}, nil
+			} else {
+				return nil, errors.InvalidArgumentError{
+					Expected: "XML-serializable value (string, float64 or Node)",
+					Actual:   item,
+				}
+			}
+		}
+	}
 }

--- a/pkg/expression/xpath_test.go
+++ b/pkg/expression/xpath_test.go
@@ -11,6 +11,8 @@ package expression
 import (
 	"testing"
 
+	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/data"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,4 +25,33 @@ func TestXPath(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.True(t, result.(bool))
+}
+
+type dataObjects map[string]data.ItemAware
+
+func (d dataObjects) FindItemAwareById(id bpmn.IdRef) (itemAware data.ItemAware, found bool) {
+	itemAware, found = d[id]
+	return
+}
+
+func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware, found bool) {
+	itemAware, found = d[name]
+	return
+}
+
+func TestXPath_getDataObject(t *testing.T) {
+	// This funtionality doesn't quite work yet
+	t.SkipNow()
+	var engine = NewXPath()
+	container := data.NewContainer(nil)
+	container.Put(data.XMLSource(`<tag attr="val"/>`))
+	var objs dataObjects = map[string]data.ItemAware{
+		"dataObject": container,
+	}
+	engine.SetItemAwareLocator(objs)
+	compiled, err := engine.CompileExpression("(getDataObject('dataObject')/tag/@attr/string())[1]")
+	assert.Nil(t, err)
+	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{})
+	assert.Nil(t, err)
+	assert.Equal(t, "val", result.(string))
 }

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -16,8 +16,7 @@ import (
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/process"
 	"bpxe.org/pkg/tracing"
-
-	_ "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testCondExpr bpmn.Definitions
@@ -97,4 +96,53 @@ func TestFalseFormalExpression(t *testing.T) {
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}
+}
+
+var testCondDataObject bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/condexpr_dataobject.bpmn", testdata, &testCondDataObject)
+}
+
+func TestCondDataObject(t *testing.T) {
+	test := func(cond, expected string) func(t *testing.T) {
+		return func(t *testing.T) {
+			processElement := (*testCondDataObject.Processes())[0]
+			proc := process.New(&processElement, &testCondDataObject)
+			if instance, err := proc.Instantiate(); err == nil {
+				traces := instance.Tracer.Subscribe()
+				// Set all data objects to false by default, except for `cond`
+				for _, k := range []string{"cond1o", "cond2o"} {
+					itemAware, found := instance.FindItemAwareByName(k)
+					require.True(t, found)
+					itemAware.Put(k == cond)
+				}
+				err := instance.Run()
+				if err != nil {
+					t.Fatalf("failed to run the instance: %s", err)
+				}
+			loop:
+				for {
+					trace := <-traces
+					switch trace := trace.(type) {
+					case flow.VisitTrace:
+						if id, present := trace.Node.Id(); present {
+							if *id == expected {
+								break loop
+							}
+						}
+					case tracing.ErrorTrace:
+						t.Fatalf("%#v", trace)
+					default:
+						t.Logf("%#v", trace)
+					}
+				}
+				instance.Tracer.Unsubscribe(traces)
+			} else {
+				t.Fatalf("failed to instantiate the process: %s", err)
+			}
+		}
+	}
+	t.Run("cond1o", test("cond1o", "a1"))
+	t.Run("cond2o", test("cond2o", "a2"))
 }

--- a/pkg/flow/tests/testdata/condexpr_dataobject.bpmn
+++ b/pkg/flow/tests/testdata/condexpr_dataobject.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0hdorjb" targetNamespace="http://bpmn.io/schema/bpmn" expressionLanguage="https://github.com/antonmedv/expr" exporter="Camunda Modeler" exporterVersion="4.7.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+  <bpmn:process id="Process_1x4ppsr" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>Flow_0iuzsse</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_14p39vu">
+      <bpmn:incoming>Flow_0iuzsse</bpmn:incoming>
+      <bpmn:outgoing>cond1</bpmn:outgoing>
+      <bpmn:outgoing>cond2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0iuzsse" sourceRef="start" targetRef="Gateway_14p39vu" />
+    <bpmn:task id="a1" name="a1">
+      <bpmn:incoming>cond1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gwt8id</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="cond1" name="cond1" sourceRef="Gateway_14p39vu" targetRef="a1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">getDataObject('cond1o')</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:task id="a2" name="a2">
+      <bpmn:incoming>cond2</bpmn:incoming>
+      <bpmn:outgoing>Flow_04cxx78</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="cond2" name="cond2" sourceRef="Gateway_14p39vu" targetRef="a2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">getDataObject('cond2o')</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_0gwt8id</bpmn:incoming>
+      <bpmn:incoming>Flow_04cxx78</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0gwt8id" sourceRef="a1" targetRef="end" />
+    <bpmn:sequenceFlow id="Flow_04cxx78" sourceRef="a2" targetRef="end" />
+    <bpmn:dataObject id="cond2o" name="cond2o" />
+    <bpmn:dataObject id="cond1o" name="cond1o" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1x4ppsr">
+      <bpmndi:BPMNEdge id="Flow_04cxx78_di" bpmnElement="Flow_04cxx78">
+        <di:waypoint x="470" y="230" />
+        <di:waypoint x="501" y="230" />
+        <di:waypoint x="501" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gwt8id_di" bpmnElement="Flow_0gwt8id">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lkl4uy_di" bpmnElement="cond2">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="230" />
+        <di:waypoint x="370" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="290" y="183" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ksa6la_di" bpmnElement="cond1">
+        <di:waypoint x="315" y="117" />
+        <di:waypoint x="370" y="117" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="328" y="99" width="30" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0iuzsse_di" bpmnElement="Flow_0iuzsse">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_14p39vu_di" bpmnElement="Gateway_14p39vu" isMarkerVisible="true">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ricf4t_di" bpmnElement="a1">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0w23q9e_di" bpmnElement="a2">
+        <dc:Bounds x="370" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07rvpsv_di" bpmnElement="end">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/pkg/flow_node/activity/harness.go
+++ b/pkg/flow_node/activity/harness.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 
 	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/data"
 	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/flow/flow_interface"
@@ -89,6 +90,7 @@ func NewHarness(process *bpmn.Process,
 	idGenerator id.Generator,
 	constructor Constructor,
 	instanceBuilder event.InstanceBuilder,
+	itemAwareLocator data.ItemAwareLocator,
 ) (node *Harness, err error) {
 	flowNode, err := flow_node.New(process,
 		definitions,
@@ -154,7 +156,7 @@ func NewHarness(process *bpmn.Process,
 				}
 			}
 			newFlow := flow.New(node.T.Definitions, catchEvent, node.T.Tracer,
-				node.T.FlowNodeMapping, node.T.FlowWaitGroup, node.idGenerator, actionTransformer)
+				node.T.FlowNodeMapping, node.T.FlowWaitGroup, node.idGenerator, actionTransformer, itemAwareLocator)
 			newFlow.Start()
 		}
 	}

--- a/schema-codegen.xsl
+++ b/schema-codegen.xsl
@@ -71,11 +71,11 @@
         <xsl:text>type </xsl:text>
         <xsl:value-of select="local:struct-case($type/@name)"/>
         <xsl:text> struct {  </xsl:text>
-        <xsl:if test="exists(./xs:complexContent/xs:extension[@base])">
-            <xsl:value-of select="local:struct-case(./xs:complexContent/xs:extension/@base)"/>
+        <xsl:for-each select="./xs:complexContent/xs:extension[@base]">
+            <xsl:value-of select="local:struct-case(./@base)"/>
             <xsl:text xml:space="preserve">
             </xsl:text>
-        </xsl:if>
+        </xsl:for-each>
         <xsl:for-each select=".//xs:attribute">
             <xsl:value-of select="local:field-name(.)"/>
             <xsl:text xml:space="preserve"> </xsl:text>
@@ -108,7 +108,9 @@
                 <xsl:otherwise/>
             </xsl:choose>
         </xsl:for-each>
-        <xsl:text>TextPayloadField string `xml:",chardata"`</xsl:text>
+        <xsl:if test="not($type/@abstract)">
+            <xsl:text>TextPayloadField string `xml:",chardata"`</xsl:text>
+        </xsl:if>
         <xsl:text xml:space="preserve"> }
         </xsl:text>
         <!-- Constructor -->
@@ -160,13 +162,13 @@
         <xsl:text xml:space="preserve">{
         </xsl:text>
         
-        <xsl:if test="exists(./xs:complexContent/xs:extension[@base])">
-            <xsl:value-of select="local:struct-case(./xs:complexContent/xs:extension/@base)"/>
+        <xsl:for-each select="./xs:complexContent/xs:extension[@base]">
+            <xsl:value-of select="local:struct-case(./@base)"/>
             <xsl:text>: Default</xsl:text>
-            <xsl:value-of select="local:struct-case(./xs:complexContent/xs:extension/@base)"/>
+            <xsl:value-of select="local:struct-case(./@base)"/>
             <xsl:text xml:space="preserve">(),
             </xsl:text>
-        </xsl:if>
+        </xsl:for-each>
         
         <xsl:for-each select=".//xs:attribute[exists(@default)]">
             <xsl:if test="not(contains(./@default, '#'))">
@@ -202,11 +204,11 @@
             Element
         </xsl:text>
            
-        <xsl:if test="exists(./xs:complexContent/xs:extension[@base])">
-            <xsl:value-of select="local:struct-case(./xs:complexContent/xs:extension/@base)"/>
+        <xsl:for-each select="./xs:complexContent/xs:extension[@base]">
+            <xsl:value-of select="local:struct-case(./@base)"/>
             <xsl:text xml:space="preserve">Interface
             </xsl:text>
-        </xsl:if>
+        </xsl:for-each>
         
         <!-- Getters -->
         <xsl:for-each select=".//xs:attribute">
@@ -287,19 +289,23 @@
             </xsl:choose>
         </xsl:for-each>
         <!-- Text payload -->
-        <xsl:text>
-            TextPayload() *string
-        </xsl:text>
+        <xsl:if test="not($type/@abstract)">
+            <xsl:text>
+                TextPayload() *string
+            </xsl:text>
+        </xsl:if>
         
         <xsl:text xml:space="preserve"> }
         </xsl:text>
         <!-- Interface implementation -->
-        <xsl:text xml:space="preserve">
+        <xsl:if test="not($type/@abstract)">
+            <xsl:text xml:space="preserve">
             func (t *</xsl:text><xsl:value-of select="local:struct-case($type/@name)"/>
-        <xsl:text xml:space="preserve">) TextPayload() *string {
+            <xsl:text xml:space="preserve">) TextPayload() *string {
             return &amp;t.TextPayloadField
          }
         </xsl:text>
+        </xsl:if>
         
         <xsl:text xml:space="preserve">func (t *</xsl:text><xsl:value-of select="local:struct-case($type/@name)"/>
         <xsl:text xml:space="preserve">) FindBy(f ElementPredicate) (result Element, found bool) {
@@ -312,13 +318,13 @@
             return
             }
         </xsl:text>
-        <xsl:if test="exists(./xs:complexContent/xs:extension[@base])">
-            <xsl:text>if result, found = t.</xsl:text><xsl:value-of select="local:struct-case(./xs:complexContent/xs:extension/@base)"/>
+        <xsl:for-each select="./xs:complexContent/xs:extension[@base]">
+            <xsl:text>if result, found = t.</xsl:text><xsl:value-of select="local:struct-case(./@base)"/>
             <xsl:text xml:space="preserve">.FindBy(f); found {
                 return
             }
             </xsl:text>
-        </xsl:if>
+        </xsl:for-each>
         <xsl:for-each select="local:specific-elements(.)">
             <xsl:variable name="ref" select="./@ref"/>
             <xsl:choose>

--- a/schemas/Semantic-original.xsd
+++ b/schemas/Semantic-original.xsd
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
 	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.w3.org/2001/XMLSchema XMLSchema-modified.xsd"
 	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
 
 	<xsd:element name="activity" type="tActivity"/>
@@ -478,8 +476,12 @@
 	<xsd:element name="dataInput" type="tDataInput"/>
 	<xsd:complexType name="tDataInput">
 		<xsd:complexContent>
-			<xsd:extension base="tItemAwareElement">
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
 				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -495,8 +497,11 @@
 	<xsd:element name="dataObject" type="tDataObject" substitutionGroup="flowElement"/>
 	<xsd:complexType name="tDataObject">
 		<xsd:complexContent>
-			<xsd:extension base="tFlowElement"/>
-			<xsd:extension base="tItemAware">
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -506,8 +511,11 @@
 		substitutionGroup="flowElement"/>
 	<xsd:complexType name="tDataObjectReference">
 		<xsd:complexContent>
-			<xsd:extension base="tFlowElement"/>
-			<xsd:extension base="tItemAware">
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 				<xsd:attribute name="dataObjectRef" type="xsd:IDREF"/>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -516,8 +524,12 @@
 	<xsd:element name="dataOutput" type="tDataOutput"/>
 	<xsd:complexType name="tDataOutput">
 		<xsd:complexContent>
-			<xsd:extension base="tItemAwareElement">
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
 				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -542,11 +554,14 @@
 	<xsd:element name="dataStore" type="tDataStore" substitutionGroup="rootElement"/>
 	<xsd:complexType name="tDataStore">
 		<xsd:complexContent>
-			<xsd:extension base="tRootElement"/>
-			<xsd:extension base="tItemAware">
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
 				<xsd:attribute name="name" type="xsd:string"/>
 				<xsd:attribute name="capacity" type="xsd:integer"/>
 				<xsd:attribute name="isUnlimited" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -555,8 +570,11 @@
 		substitutionGroup="flowElement"/>
 	<xsd:complexType name="tDataStoreReference">
 		<xsd:complexContent>
-			<xsd:extension base="tFlowElement"/>
-			<xsd:extension base="tItemAware">
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 				<xsd:attribute name="dataStoreRef" type="xsd:QName"/>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -941,20 +959,6 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="tItemAware" abstract="true">
-				<xsd:sequence>
-					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
-				</xsd:sequence>
-				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
-	</xsd:complexType>
-	
-	<xsd:complexType name="tItemAwareElement" abstract="true">
-		<xsd:complexContent>
-			<xsd:extension base="tBaseElement"/>
-			<xsd:extension base="tItemAware"/>
-		</xsd:complexContent>
-	</xsd:complexType>
-
 	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="rootElement"/>
 	<xsd:complexType name="tItemDefinition">
 		<xsd:complexContent>
@@ -1276,8 +1280,12 @@
 	<xsd:element name="property" type="tProperty"/>
 	<xsd:complexType name="tProperty">
 		<xsd:complexContent>
-			<xsd:extension base="tItemAwareElement">
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
 				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/schemas/XMLSchema-modified.xsd
+++ b/schemas/XMLSchema-modified.xsd
@@ -1,0 +1,1950 @@
+<?xml version='1.0'?>
+
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XSD 1.1//EN" "XMLSchema.dtd" [
+
+<!-- provide ID type information even for parsers which only read the
+     internal subset -->
+<!ATTLIST xs:schema          id  ID  #IMPLIED>
+<!ATTLIST xs:complexType     id  ID  #IMPLIED>
+<!ATTLIST xs:complexContent  id  ID  #IMPLIED>
+<!ATTLIST xs:simpleContent   id  ID  #IMPLIED>
+<!ATTLIST xs:extension       id  ID  #IMPLIED>
+<!ATTLIST xs:element         id  ID  #IMPLIED>
+<!ATTLIST xs:group           id  ID  #IMPLIED> 
+<!ATTLIST xs:all             id  ID  #IMPLIED>
+<!ATTLIST xs:choice          id  ID  #IMPLIED>
+<!ATTLIST xs:sequence        id  ID  #IMPLIED>
+<!ATTLIST xs:any             id  ID  #IMPLIED>
+<!ATTLIST xs:anyAttribute    id  ID  #IMPLIED>
+<!ATTLIST xs:attribute       id  ID  #IMPLIED>
+<!ATTLIST xs:attributeGroup  id  ID  #IMPLIED>
+<!ATTLIST xs:unique          id  ID  #IMPLIED>
+<!ATTLIST xs:key             id  ID  #IMPLIED>
+<!ATTLIST xs:keyref          id  ID  #IMPLIED>
+<!ATTLIST xs:selector        id  ID  #IMPLIED>
+<!ATTLIST xs:field           id  ID  #IMPLIED>
+<!ATTLIST xs:assert          id  ID  #IMPLIED>
+<!ATTLIST xs:include         id  ID  #IMPLIED>
+<!ATTLIST xs:import          id  ID  #IMPLIED>
+<!ATTLIST xs:redefine        id  ID  #IMPLIED>
+<!ATTLIST xs:override        id  ID  #IMPLIED>
+<!ATTLIST xs:notation        id  ID  #IMPLIED>
+<!--
+        Make sure that processors that do not read the external
+        subset will know about the various IDs we declare
+  -->
+        <!ATTLIST xs:simpleType id ID #IMPLIED>
+        <!ATTLIST xs:maxExclusive id ID #IMPLIED>
+        <!ATTLIST xs:minExclusive id ID #IMPLIED>
+        <!ATTLIST xs:maxInclusive id ID #IMPLIED>
+        <!ATTLIST xs:minInclusive id ID #IMPLIED>
+        <!ATTLIST xs:totalDigits id ID #IMPLIED>
+        <!ATTLIST xs:fractionDigits id ID #IMPLIED>
+        <!ATTLIST xs:length id ID #IMPLIED>
+        <!ATTLIST xs:minLength id ID #IMPLIED>
+        <!ATTLIST xs:maxLength id ID #IMPLIED>
+        <!ATTLIST xs:enumeration id ID #IMPLIED>
+        <!ATTLIST xs:pattern id ID #IMPLIED>
+        <!ATTLIST xs:assertion id ID #IMPLIED>
+        <!ATTLIST xs:explicitTimezone id ID #IMPLIED>
+        <!ATTLIST xs:appinfo id ID #IMPLIED>
+        <!ATTLIST xs:documentation id ID #IMPLIED>
+        <!ATTLIST xs:list id ID #IMPLIED>
+        <!ATTLIST xs:union id ID #IMPLIED>
+        ]>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified" xml:lang="EN"
+           targetNamespace="http://www.w3.org/2001/XMLSchema"
+           version="1.0">
+ <xs:annotation>
+  <xs:documentation>
+    Part 1 version: structures.xsd (rec-20120405)
+    Part 2 version: datatypes.xsd (rec-20120405)
+  </xs:documentation>
+ </xs:annotation>
+
+  <xs:annotation>
+    <xs:documentation  source="../structures/structures.html">
+   The schema corresponding to this document is normative,
+   with respect to the syntactic constraints it expresses in the
+   XML Schema Definition Language.  The documentation (within 'documentation' elements)
+   below, is not normative, but rather highlights important aspects of
+   the W3C Recommendation of which this is a part.
+
+      See below (at the bottom of this document) for information about
+      the revision and namespace-versioning policy governing this
+      schema document.
+
+    </xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+    <xs:documentation>
+   The simpleType element and all of its members are defined
+   towards the end of this schema document.</xs:documentation>
+ </xs:annotation>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/xml.xsd">
+    <xs:annotation>
+      <xs:documentation>
+       Get access to the xml: attribute groups for xml:lang
+       as declared on 'schema' and 'documentation' below
+     </xs:documentation>
+    </xs:annotation>
+  </xs:import>
+  <xs:complexType name="openAttrs">
+    <xs:annotation>
+      <xs:documentation>
+       This type is extended by almost all schema types
+       to allow attributes from other namespaces to be
+       added to user schemas.
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:anyType">
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="annotated">
+    <xs:annotation>
+      <xs:documentation>
+       This type is extended by all types which allow annotation
+       other than &lt;schema> itself
+     </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:openAttrs">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:ID"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="composition">
+    <xs:choice>
+      <xs:element ref="xs:include"/>
+      <xs:element ref="xs:import"/>
+      <xs:element ref="xs:redefine"/>
+      <xs:element ref="xs:override"/>
+      <xs:element ref="xs:annotation"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="schemaTop">
+    <xs:annotation>
+      <xs:documentation>
+   This group is for the
+   elements which occur freely at the top level of schemas.
+   All of their types are based on the "annotated" type by extension.</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:group ref="xs:redefinable"/>
+      <xs:element ref="xs:element"/>
+      <xs:element ref="xs:attribute"/>
+      <xs:element ref="xs:notation"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="redefinable">
+    <xs:annotation>
+      <xs:documentation>
+   This group is for the
+   elements which can self-redefine (see &lt;redefine> below).</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="xs:simpleType"/>
+      <xs:element ref="xs:complexType"/>
+      <xs:element ref="xs:group"/>
+      <xs:element ref="xs:attributeGroup"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="formChoice">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="qualified"/>
+      <xs:enumeration value="unqualified"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="reducedDerivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:derivationControl">
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="derivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list itemType="xs:reducedDerivationControl"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:simpleType name="typeDerivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:derivationControl">
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="union"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="fullDerivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {extension, restriction, list, union}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list itemType="xs:typeDerivationControl"/>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:element name="schema" id="schema">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-schema"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:sequence>
+            <xs:group ref="xs:composition" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:sequence minOccurs="0">
+              <xs:element ref="xs:defaultOpenContent"/>
+              <xs:element ref="xs:annotation" minOccurs="0"
+                          maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:group ref="xs:schemaTop"/>
+              <xs:element ref="xs:annotation" minOccurs="0"
+                          maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:sequence>
+          <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+          <xs:attribute name="version" type="xs:token"/>
+          <xs:attribute name="finalDefault" type="xs:fullDerivationSet"
+                        default="" use="optional"/>
+          <xs:attribute name="blockDefault" type="xs:blockSet" default=""
+                        use="optional"/>
+          <xs:attribute name="attributeFormDefault" type="xs:formChoice"
+                        default="unqualified" use="optional"/>
+          <xs:attribute name="elementFormDefault" type="xs:formChoice"
+                        default="unqualified" use="optional"/>
+          <xs:attribute name="defaultAttributes" type="xs:QName"/>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"
+                        default="##local" use="optional"/>
+          <xs:attribute name="id" type="xs:ID"/>
+          <xs:attribute ref="xml:lang"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+    <xs:key name="element">
+      <xs:selector xpath="xs:element"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="attribute">
+      <xs:selector xpath="xs:attribute"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="type">
+      <xs:selector xpath="xs:complexType|xs:simpleType"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="group">
+      <xs:selector xpath="xs:group"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="attributeGroup">
+      <xs:selector xpath="xs:attributeGroup"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="notation">
+      <xs:selector xpath="xs:notation"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+    <xs:key name="identityConstraint">
+      <xs:selector xpath=".//xs:key|.//xs:unique|.//xs:keyref"/>
+      <xs:field xpath="@name"/>
+    </xs:key>
+  </xs:element>
+  <xs:simpleType name="allNNI">
+    <xs:annotation>
+      <xs:documentation>
+   for maxOccurs</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xs:nonNegativeInteger">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="unbounded"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:attributeGroup name="occurs">
+    <xs:annotation>
+      <xs:documentation>
+   for all particles</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="minOccurs" type="xs:nonNegativeInteger" default="1"
+                  use="optional"/>
+    <xs:attribute name="maxOccurs" type="xs:allNNI" default="1" use="optional"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="defRef">
+    <xs:annotation>
+      <xs:documentation>
+   for element, group and attributeGroup,
+   which both define and reference</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:NCName"/>
+    <xs:attribute name="ref" type="xs:QName"/>
+  </xs:attributeGroup>
+  <xs:group name="typeDefParticle">
+    <xs:annotation>
+      <xs:documentation>
+   'complexType' uses this</xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element name="group" type="xs:groupRef"/>
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="nestedParticle">
+    <xs:choice>
+      <xs:element name="element" type="xs:localElement"/>
+      <xs:element name="group" type="xs:groupRef"/>
+      
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+      <xs:element ref="xs:any"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="particle">
+    <xs:choice>
+      <xs:element name="element" type="xs:localElement"/>
+      <xs:element name="group" type="xs:groupRef"/>
+      <xs:element ref="xs:all"/>
+      <xs:element ref="xs:choice"/>
+      <xs:element ref="xs:sequence"/>
+      <xs:element ref="xs:any"/>
+    </xs:choice>
+  </xs:group>
+  <xs:complexType name="attribute">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attribute name="type" type="xs:QName"/>
+        <xs:attribute name="use" default="optional" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:NMTOKEN">
+              <xs:enumeration value="prohibited"/>
+              <xs:enumeration value="optional"/>
+              <xs:enumeration value="required"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="default" type="xs:string"/>
+        <xs:attribute name="fixed" type="xs:string"/>
+        <xs:attribute name="form" type="xs:formChoice"/>
+        <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+          
+        <xs:attribute name="inheritable" type="xs:boolean"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelAttribute">
+    <xs:complexContent>
+      <xs:restriction base="xs:attribute">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="form" use="prohibited"/>
+        <xs:attribute name="use" use="prohibited"/>
+        <xs:attribute name="targetNamespace" use="prohibited"/>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="inheritable" type="xs:boolean"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="attrDecls">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="attribute" type="xs:attribute"/>
+        <xs:element name="attributeGroup" type="xs:attributeGroupRef"/>
+      </xs:choice>
+      <xs:element ref="xs:anyAttribute" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="anyAttribute"  id="anyAttribute">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-anyAttribute"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:wildcard">
+          <xs:attribute name="notQName" type="xs:qnameListA"
+                        use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="assertions">
+    <xs:sequence>
+      <xs:element name="assert" type="xs:assertion"
+                  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="assertion">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:attribute name="test" type="xs:string"/>
+        <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="complexTypeModel">
+    <xs:choice>
+      <xs:element ref="xs:simpleContent"/>
+      <xs:element ref="xs:complexContent"/>
+      <xs:sequence>
+        <xs:annotation>
+          <xs:documentation>
+   This branch is short for
+   &lt;complexContent>
+   &lt;restriction base="xs:anyType">
+   ...
+   &lt;/restriction>
+   &lt;/complexContent></xs:documentation>
+        </xs:annotation>
+        <xs:element ref="xs:openContent" minOccurs="0"/>
+        <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+        <xs:group ref="xs:attrDecls"/>
+        <xs:group ref="xs:assertions"/>
+      </xs:sequence>
+    </xs:choice>
+  </xs:group>
+  <xs:complexType name="complexType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:group ref="xs:complexTypeModel"/>
+        <xs:attribute name="name" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+      Will be restricted to required or prohibited</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mixed" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+      Not allowed if simpleContent child is chosen.
+      May be overridden by setting on complexContent child.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="abstract" type="xs:boolean" default="false"
+                      use="optional"/>
+        <xs:attribute name="final" type="xs:derivationSet"/>
+        <xs:attribute name="block" type="xs:derivationSet"/>
+        <xs:attribute name="defaultAttributesApply" type="xs:boolean"
+                      default="true" use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelComplexType">
+    <xs:complexContent>
+      <xs:restriction base="xs:complexType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:complexTypeModel"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localComplexType">
+    <xs:complexContent>
+      <xs:restriction base="xs:complexType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:complexTypeModel"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:attribute name="abstract" use="prohibited"/>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:attribute name="block" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="restrictionType">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            
+            <xs:sequence>
+              <xs:element ref="xs:openContent" minOccurs="0"/>
+              <xs:group ref="xs:typeDefParticle"/>
+            </xs:sequence>
+            <xs:group ref="xs:simpleRestrictionModel"/>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:attribute name="base" type="xs:QName" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="complexRestrictionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:restrictionType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+            </xs:annotation>
+            
+            <xs:sequence>
+              <xs:element ref="xs:openContent" minOccurs="0"/>
+              <xs:group ref="xs:typeDefParticle"/>
+            </xs:sequence>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="extensionType">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:element ref="xs:openContent" minOccurs="0"/>
+          <xs:group ref="xs:typeDefParticle" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:attribute name="base" type="xs:QName" use="required"/>
+        
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="complexContent" id="complexContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-complexContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:choice>
+            <xs:element name="restriction" type="xs:complexRestrictionType"/>
+            <xs:element name="extension" type="xs:extensionType" maxOccurs="unbounded"/>
+          </xs:choice>
+          <xs:attribute name="mixed" type="xs:boolean">
+            <xs:annotation>
+              <xs:documentation>
+       Overrides any setting on complexType parent.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="openContent" id="openContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-openContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="any" minOccurs="0" type="xs:wildcard"/>
+          </xs:sequence>
+          <xs:attribute name="mode" default="interleave" use="optional">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="none"/>
+                <xs:enumeration value="interleave"/>
+                <xs:enumeration value="suffix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="defaultOpenContent" id="defaultOpenContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-defaultOpenContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="any" type="xs:wildcard"/>
+          </xs:sequence>
+          <xs:attribute name="appliesToEmpty" type="xs:boolean"
+                        default="false" use="optional"/>
+          <xs:attribute name="mode" default="interleave" use="optional">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="interleave"/>
+                <xs:enumeration value="suffix"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="simpleRestrictionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:restrictionType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>This choice is added simply to
+                   make this a valid restriction per the REC</xs:documentation>
+            </xs:annotation>
+            <xs:group ref="xs:simpleRestrictionModel"/>
+          </xs:choice>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="simpleExtensionType">
+    <xs:complexContent>
+      <xs:restriction base="xs:extensionType">
+        <xs:sequence>
+          <xs:annotation>
+            <xs:documentation>
+      No typeDefParticle group reference</xs:documentation>
+          </xs:annotation>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          <xs:group ref="xs:assertions"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="simpleContent" id="simpleContent">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-simpleContent"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:choice>
+            <xs:element name="restriction" type="xs:simpleRestrictionType"/>
+            <xs:element name="extension" type="xs:simpleExtensionType"/>
+          </xs:choice>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="complexType" type="xs:topLevelComplexType" id="complexType">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-complexType"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:simpleType name="blockSet">
+    <xs:annotation>
+      <xs:documentation>
+    A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+    #all or (possibly empty) subset of {substitution, extension,
+    restriction}</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:derivationControl">
+              <xs:enumeration value="extension"/>
+              <xs:enumeration value="restriction"/>
+              <xs:enumeration value="substitution"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:complexType name="element" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+   The element element can be used either
+   at the top level to define an element-type binding globally,
+   or within a content model to either reference a globally-defined
+   element or type or declare an element-type binding locally.
+   The ref form is not allowed at the top level.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attribute name="type" type="xs:QName"/>
+        
+        <xs:attribute name="substitutionGroup">
+         <xs:simpleType>
+          <xs:list itemType="xs:QName"/>
+         </xs:simpleType>
+        </xs:attribute>
+        <xs:attributeGroup ref="xs:occurs"/>
+        <xs:attribute name="default" type="xs:string"/>
+        <xs:attribute name="fixed" type="xs:string"/>
+        <xs:attribute name="nillable" type="xs:boolean" use="optional"/>
+        <xs:attribute name="abstract" type="xs:boolean" default="false"
+                      use="optional"/>
+        <xs:attribute name="final" type="xs:derivationSet"/>
+        <xs:attribute name="block" type="xs:blockSet"/>
+        <xs:attribute name="form" type="xs:formChoice"/>
+        <xs:attribute name="targetNamespace" type="xs:anyURI"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelElement">
+    <xs:complexContent>
+      <xs:restriction base="xs:element">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="form" use="prohibited"/>
+        <xs:attribute name="targetNamespace" use="prohibited"/>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localElement">
+    <xs:complexContent>
+      <xs:restriction base="xs:element">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0">
+            <xs:element name="simpleType" type="xs:localSimpleType"/>
+            <xs:element name="complexType" type="xs:localComplexType"/>
+          </xs:choice>
+          <xs:element name="alternative" type="xs:altType" 
+                    minOccurs="0" maxOccurs="unbounded"/>
+          <xs:group ref="xs:identityConstraint" minOccurs="0"
+                    maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="substitutionGroup" use="prohibited"/>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:attribute name="abstract" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="element" type="xs:topLevelElement" id="element">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-element"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="altType">
+    <xs:annotation>
+      <xs:documentation>
+        This type is used for 'alternative' elements.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:choice minOccurs="0">
+          <xs:element name="simpleType" type="xs:localSimpleType"/>
+          <xs:element name="complexType" type="xs:localComplexType"/>
+        </xs:choice>
+        <xs:attribute name="test" type="xs:string" use="optional"/>
+        <xs:attribute name="type" type="xs:QName" use="optional"/>
+        <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="group" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+   group type for explicit groups, named top-level groups and
+   group references</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+          <xs:group ref="xs:particle" minOccurs="0" maxOccurs="unbounded"/>
+          
+        <xs:attributeGroup ref="xs:defRef"/>
+        <xs:attributeGroup ref="xs:occurs"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="realGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:group">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="0" maxOccurs="1">
+            <xs:element ref="xs:all"/>
+            <xs:element ref="xs:choice"/>
+            <xs:element ref="xs:sequence"/>
+          </xs:choice>
+          
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="namedGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:realGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="all">
+              <xs:complexType>
+                <xs:complexContent>
+                  <xs:restriction base="xs:all">
+                    <xs:group ref="xs:allModel"/>
+                    <xs:attribute name="minOccurs" use="prohibited"/>
+                    <xs:attribute name="maxOccurs" use="prohibited"/>
+                    <xs:anyAttribute namespace="##other" processContents="lax"/>
+                  </xs:restriction>
+                </xs:complexContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="choice" type="xs:simpleExplicitGroup"/>
+            <xs:element name="sequence" type="xs:simpleExplicitGroup"/>
+          </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="groupRef">
+    <xs:complexContent>
+      <xs:restriction base="xs:realGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" type="xs:QName" use="required"/>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="explicitGroup">
+    <xs:annotation>
+      <xs:documentation>
+   group type for the three kinds of group</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:group">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="simpleExplicitGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:explicitGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:nestedParticle" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="minOccurs" use="prohibited"/>
+        <xs:attribute name="maxOccurs" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="allModel">
+    <xs:sequence>
+      <xs:element ref="xs:annotation" minOccurs="0"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>This choice with min/max is here to
+                          avoid a pblm with the Elt:All/Choice/Seq
+                          Particle derivation constraint</xs:documentation>
+        </xs:annotation>
+        <xs:element name="element" type="xs:localElement"/>
+        <xs:element ref="xs:any"/>
+        <xs:element name="group">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:restriction base="xs:groupRef">
+                <xs:sequence>
+                  <xs:element ref="xs:annotation" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="minOccurs" fixed="1" type="xs:nonNegativeInteger"/>
+                <xs:attribute name="maxOccurs" fixed="1" type="xs:nonNegativeInteger"/>
+              </xs:restriction>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:complexType name="all">
+    <xs:annotation>
+      <xs:documentation>
+   Only elements allowed inside</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="xs:explicitGroup">
+        <xs:group ref="xs:allModel"/>
+        <xs:attribute name="minOccurs" default="1" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:nonNegativeInteger">
+              <xs:enumeration value="0"/>
+              <xs:enumeration value="1"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="maxOccurs" default="1" use="optional">
+          <xs:simpleType>
+            <xs:restriction base="xs:allNNI">
+              <xs:enumeration value="0"/>
+              <xs:enumeration value="1"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="all" type="xs:all" id="all">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-all"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="choice" type="xs:explicitGroup" id="choice">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-choice"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="sequence" type="xs:explicitGroup" id="sequence">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-sequence"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="group" type="xs:namedGroup" id="group">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-group"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:attributeGroup name="anyAttrGroup">
+    <xs:attribute name="namespace" type="xs:namespaceList"
+                  use="optional"/>
+    <xs:attribute name="notNamespace" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:basicNamespaceList">
+          <xs:minLength value="1"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="processContents" default="strict" use="optional">
+      <xs:simpleType>
+        <xs:restriction base="xs:NMTOKEN">
+          <xs:enumeration value="skip"/>
+          <xs:enumeration value="lax"/>
+          <xs:enumeration value="strict"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:complexType name="wildcard">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+         <xs:attributeGroup ref="xs:anyAttrGroup"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="any" id="any">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-any"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:wildcard">
+          <xs:attribute name="notQName" type="xs:qnameList"
+                        use="optional"/>
+          <xs:attributeGroup ref="xs:occurs"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:annotation>
+    <xs:documentation>
+   simple type for the value of the 'namespace' attr of
+   'any' and 'anyAttribute'</xs:documentation>
+  </xs:annotation>
+  <xs:annotation>
+    <xs:documentation>
+   Value is
+              ##any      - - any non-conflicting WFXML/attribute at all
+
+              ##other    - - any non-conflicting WFXML/attribute from
+                              namespace other than targetNS
+
+              ##local    - - any unqualified non-conflicting WFXML/attribute 
+
+              one or     - - any non-conflicting WFXML/attribute from
+              more URI        the listed namespaces
+              references
+              (space separated)
+
+    ##targetNamespace or ##local may appear in the above list, to
+        refer to the targetNamespace of the enclosing
+        schema or an absent targetNamespace respectively</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType name="namespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    
+    <xs:union memberTypes="xs:specialNamespaceList xs:basicNamespaceList" />
+  </xs:simpleType>
+  <xs:simpleType name="basicNamespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:anyURI">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##targetNamespace"/>
+              <xs:enumeration value="##local"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="specialNamespaceList">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="##any"/>
+      <xs:enumeration value="##other"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="qnameList">
+    <xs:annotation>
+      <xs:documentation>
+        A utility type, not for public use
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:QName">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##defined"/>
+              <xs:enumeration value="##definedSibling"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="qnameListA">
+    <xs:annotation>
+      <xs:documentation>
+        A utility type, not for public use
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list>
+      <xs:simpleType>
+        <xs:union memberTypes="xs:QName">
+          <xs:simpleType>
+            <xs:restriction base="xs:token">
+              <xs:enumeration value="##defined"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:list>
+  </xs:simpleType>
+  <xs:simpleType name="xpathDefaultNamespace">
+    <xs:union memberTypes="xs:anyURI">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="##defaultNamespace"/>
+          <xs:enumeration value="##targetNamespace"/>
+          <xs:enumeration value="##local"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:element name="attribute" type="xs:topLevelAttribute" id="attribute">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-attribute"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="attributeGroup" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        
+          <xs:group ref="xs:attrDecls"/>
+          
+        <xs:attributeGroup ref="xs:defRef"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="namedAttributeGroup">
+    <xs:complexContent>
+      <xs:restriction base="xs:attributeGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:attrDecls"/>
+          
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="ref" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="attributeGroupRef">
+    <xs:complexContent>
+      <xs:restriction base="xs:attributeGroup">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="ref" type="xs:QName" use="required"/>
+        <xs:attribute name="name" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="attributeGroup" type="xs:namedAttributeGroup"
+              id="attributeGroup">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-attributeGroup"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="include" id="include">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-include"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="redefine" id="redefine">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-redefine"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xs:annotation"/>
+            <xs:group ref="xs:redefinable"/>
+          </xs:choice>
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="override" id="override">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-override"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+            <xs:group ref="xs:schemaTop" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="schemaLocation" type="xs:anyURI" use="required"/>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="import" id="import">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-import"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="namespace" type="xs:anyURI"/>
+          <xs:attribute name="schemaLocation" type="xs:anyURI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="selector" id="selector">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-selector"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="xpath" use="required">
+            <xs:simpleType>
+              <xs:annotation>
+                <xs:documentation>A subset of XPath expressions for use
+in selectors</xs:documentation>
+                <xs:documentation>A utility type, not for public
+use</xs:documentation>
+              </xs:annotation>
+              <xs:restriction base="xs:token"/>
+                
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="field" id="field">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-field"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="xpath" use="required">
+            <xs:simpleType>
+              <xs:annotation>
+                <xs:documentation>A subset of XPath expressions for use
+in fields</xs:documentation>
+                <xs:documentation>A utility type, not for public
+use</xs:documentation>
+              </xs:annotation>
+              <xs:restriction base="xs:token"/>
+                
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="xpathDefaultNamespace" type="xs:xpathDefaultNamespace"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="keybase">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:sequence minOccurs="0">
+          <xs:element ref="xs:selector"/>
+          <xs:element ref="xs:field" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName"/>
+        <xs:attribute name="ref" type="xs:QName"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:group name="identityConstraint">
+    <xs:annotation>
+      <xs:documentation>The three kinds of identity constraints, all with
+                     type of or derived from 'keybase'.
+   </xs:documentation>
+    </xs:annotation>
+    <xs:choice>
+      <xs:element ref="xs:unique"/>
+      <xs:element ref="xs:key"/>
+      <xs:element ref="xs:keyref"/>
+    </xs:choice>
+  </xs:group>
+  <xs:element name="unique" type="xs:keybase" id="unique">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-unique"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="key" type="xs:keybase" id="key">
+    <xs:annotation>
+      <xs:documentation source="../structures/structures.html#element-key"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="keyref" id="keyref">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-keyref"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:keybase">
+          <xs:attribute name="refer" type="xs:QName"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="notation" id="notation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-notation"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:attribute name="name" type="xs:NCName" use="required"/>
+          <xs:attribute name="public" type="xs:public"/>
+          <xs:attribute name="system" type="xs:anyURI"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="public">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+      <xs:documentation>
+   A public identifier, per ISO 8879</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token"/>
+  </xs:simpleType>
+  <xs:element name="appinfo" id="appinfo">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-appinfo"/>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:any processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="source" type="xs:anyURI"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="documentation" id="documentation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-documentation"/>
+    </xs:annotation>
+    <xs:complexType mixed="true">
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:any processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="source" type="xs:anyURI"/>
+      <xs:attribute ref="xml:lang"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="annotation" id="annotation">
+    <xs:annotation>
+      <xs:documentation
+           source="../structures/structures.html#element-annotation"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xs:openAttrs">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xs:appinfo"/>
+            <xs:element ref="xs:documentation"/>
+          </xs:choice>
+          <xs:attribute name="id" type="xs:ID"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:annotation>
+    <xs:documentation>
+   notations for use within  schema documents</xs:documentation>
+  </xs:annotation>
+  <xs:notation name="XMLSchemaStructures" public="structures"
+               system="http://www.w3.org/2000/08/XMLSchema.xsd"/>
+  <xs:notation name="XML" public="REC-xml-19980210"
+               system="http://www.w3.org/TR/1998/REC-xml-19980210"/>
+  <xs:complexType name="anyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+   Not the real urType, but as close an approximation as we can
+   get in the XML representation</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+    </xs:sequence>
+    <xs:anyAttribute processContents="lax"/>
+  </xs:complexType>
+
+  <xs:annotation>
+    <xs:documentation>
+      In keeping with the XML Schema WG's standard versioning policy, 
+      the material in this schema document will persist at the URI
+      http://www.w3.org/2012/04/XMLSchema.xsd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/XMLSchema.xsd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/XMLSchema.xsd will change accordingly; 
+      the version at http://www.w3.org/2012/04/XMLSchema.xsd will not change.
+
+      Previous dated (and unchanging) versions of this schema document 
+      include:
+
+       http://www.w3.org/2012/01/XMLSchema.xsd
+          (XSD 1.1 Proposed Recommendation)
+
+        http://www.w3.org/2011/07/XMLSchema.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/XMLSchema.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/XMLSchema.xsd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/XMLSchema.xsd
+          (XSD 1.0 Recommendation, First Edition)
+
+
+    </xs:documentation>
+  </xs:annotation>
+
+
+
+
+  <xs:simpleType name="derivationControl">
+    <xs:annotation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="substitution"/>
+      <xs:enumeration value="extension"/>
+      <xs:enumeration value="restriction"/>
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="union"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="simpleDerivation">
+    <xs:choice>
+      <xs:element ref="xs:restriction"/>
+      <xs:element ref="xs:list"/>
+      <xs:element ref="xs:union"/>
+    </xs:choice>
+  </xs:group>
+  <xs:simpleType name="simpleDerivationSet">
+    <xs:annotation>
+      <xs:documentation>
+   #all or (possibly empty) subset of {restriction, extension, union, list}
+   </xs:documentation>
+      <xs:documentation>
+   A utility type, not for public use</xs:documentation>
+    </xs:annotation>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="#all"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:list>
+          <xs:simpleType>
+            <xs:restriction base="xs:derivationControl">
+              <xs:enumeration value="list"/>
+              <xs:enumeration value="union"/>
+              <xs:enumeration value="restriction"/>
+              <xs:enumeration value="extension"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:list>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:complexType name="simpleType" abstract="true">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:group ref="xs:simpleDerivation"/>
+        <xs:attribute name="final" type="xs:simpleDerivationSet"/>
+        <xs:attribute name="name" type="xs:NCName">
+          <xs:annotation>
+            <xs:documentation>
+              Can be restricted to required or forbidden
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="topLevelSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:NCName" use="required">
+          <xs:annotation>
+            <xs:documentation>
+              Required at the top level
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="localSimpleType">
+    <xs:complexContent>
+      <xs:restriction base="xs:simpleType">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+          <xs:group ref="xs:simpleDerivation"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="prohibited">
+          <xs:annotation>
+            <xs:documentation>
+              Forbidden when nested
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="simpleType" type="xs:topLevelSimpleType" id="simpleType">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-simpleType"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="facet" abstract="true">
+    <xs:annotation>
+      <xs:documentation>
+        An abstract element, representing facets in general.
+        The facets defined by this spec are substitutable for
+        this element, and implementation-defined facets should
+        also name this as a substitution-group head.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:group name="simpleRestrictionModel">
+    <xs:sequence>
+      <xs:element name="simpleType" type="xs:localSimpleType" minOccurs="0"/>
+      <xs:choice minOccurs="0" 
+          maxOccurs="unbounded">
+        <xs:element ref="xs:facet"/>
+        <xs:any processContents="lax"
+            namespace="##other"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="restriction" id="restriction">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-restriction">
+          base attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:group ref="xs:simpleRestrictionModel"/>
+          <xs:attribute name="base" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="list" id="list">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-list">
+          itemType attribute and simpleType child are mutually
+          exclusive, but one or other is required
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType"
+                        minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="itemType" type="xs:QName" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="union" id="union">
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation
+             source="http://www.w3.org/TR/xmlschema11-2/#element-union">
+          memberTypes attribute must be non-empty or there must be
+          at least one simpleType child
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexContent>
+        <xs:extension base="xs:annotated">
+          <xs:sequence>
+            <xs:element name="simpleType" type="xs:localSimpleType"
+                        minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="memberTypes" use="optional">
+            <xs:simpleType>
+              <xs:list itemType="xs:QName"/>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="facet">
+    <xs:complexContent>
+      <xs:extension base="xs:annotated">
+        <xs:attribute name="value" use="required"/>
+        <xs:attribute name="fixed" type="xs:boolean" default="false"
+                      use="optional"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="noFixedFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="fixed" use="prohibited"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="minExclusive" type="xs:facet"  
+    id="minExclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minInclusive" type="xs:facet" 
+    id="minInclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minInclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxExclusive" type="xs:facet" 
+    id="maxExclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxExclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxInclusive" type="xs:facet"  
+    id="maxInclusive"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxInclusive"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:complexType name="numFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="value"  
+            type="xs:nonNegativeInteger" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="intFacet">
+    <xs:complexContent>
+      <xs:restriction base="xs:facet">
+        <xs:sequence>
+          <xs:element ref="xs:annotation" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="value" type="xs:integer" use="required"/>
+        <xs:anyAttribute namespace="##other" processContents="lax"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="totalDigits" id="totalDigits"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-totalDigits"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:numFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:positiveInteger" use="required"/>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="fractionDigits" type="xs:numFacet"  
+    id="fractionDigits"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-fractionDigits"/>
+    </xs:annotation>
+  </xs:element>
+
+  <xs:element name="length" type="xs:numFacet" id="length"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-length"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="minLength" type="xs:numFacet"  
+    id="minLength"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-minLength"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="maxLength" type="xs:numFacet"  
+    id="maxLength"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-maxLength"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="enumeration" type="xs:noFixedFacet"  
+    id="enumeration"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-enumeration"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="whiteSpace" id="whiteSpace"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-whiteSpace"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:facet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="preserve"/>
+                <xs:enumeration value="replace"/>
+                <xs:enumeration value="collapse"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="pattern" id="pattern"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-pattern"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:noFixedFacet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" type="xs:string"  
+              use="required"/>
+          <xs:anyAttribute namespace="##other"  
+              processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="assertion" type="xs:assertion"
+              id="assertion" substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-assertion"/>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="explicitTimezone" id="explicitTimezone"
+    substitutionGroup="xs:facet">
+    <xs:annotation>
+      <xs:documentation
+           source="http://www.w3.org/TR/xmlschema11-2/#element-explicitTimezone"/>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:restriction base="xs:facet">
+          <xs:sequence>
+            <xs:element ref="xs:annotation" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="value" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="optional"/>
+                <xs:enumeration value="required"/>
+                <xs:enumeration value="prohibited"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:anyAttribute namespace="##other" processContents="lax"/>
+        </xs:restriction>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:annotation>
+    <xs:documentation>
+      In keeping with the XML Schema WG's standard versioning policy, 
+      this schema document will persist at the URI
+      http://www.w3.org/2012/04/datatypes.xsd.
+
+      At the date of issue it can also be found at the URI
+      http://www.w3.org/2009/XMLSchema/datatypes.xsd.
+
+      The schema document at that URI may however change in the future, 
+      in order to remain compatible with the latest version of XSD 
+      and its namespace.  In other words, if XSD or the XML Schema 
+      namespace change, the version of this document at 
+      http://www.w3.org/2009/XMLSchema/datatypes.xsd will change accordingly; 
+      the version at http://www.w3.org/2012/04/datatypes.xsd will not change.
+
+      Previous dated (and unchanging) versions of this schema document 
+      include:
+
+        http://www.w3.org/2012/01/datatypes.xsd
+          (XSD 1.1 Proposed Recommendation)
+
+        http://www.w3.org/2011/07/datatypes.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2009/04/datatypes.xsd
+          (XSD 1.1 Candidate Recommendation)
+
+        http://www.w3.org/2004/10/datatypes.xsd
+          (XSD 1.0 Recommendation, Second Edition)
+
+        http://www.w3.org/2001/05/datatypes.xsd
+          (XSD 1.0 Recommendation, First Edition)
+
+    </xs:documentation>
+  </xs:annotation>
+
+
+
+</xs:schema>

--- a/vendor/github.com/stretchr/testify/require/doc.go
+++ b/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,28 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//    import (
+//      "testing"
+//      "github.com/stretchr/testify/require"
+//    )
+//
+//    func TestSomething(t *testing.T) {
+//
+//      var a string = "Hello"
+//      var b string = "Hello"
+//
+//      require.Equal(t, a, b, "The two words should be the same.")
+//
+//    }
+//
+// Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,1879 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Contains(t, "Hello World", "World")
+//    assert.Contains(t, ["Hello", "World"], "World")
+//    assert.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Empty(t, obj)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  assert.Emptyf(t, obj, "error message %s", "formatted")
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equal asserts that two objects are equal.
+//
+//    assert.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Error(t, err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.Errorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventuallyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    assert.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// False asserts that the specified value is false.
+//
+//    assert.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    assert.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//    assert.Greater(t, 2, 1)
+//    assert.Greater(t, float64(2), float64(1))
+//    assert.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greater(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//    assert.GreaterOrEqual(t, 2, 1)
+//    assert.GreaterOrEqual(t, 2, 2)
+//    assert.GreaterOrEqual(t, "b", "a")
+//    assert.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//    assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//    assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//    assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+//    assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//    assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greaterf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//    assert.IsDecreasing(t, []int{2, 1, 0})
+//    assert.IsDecreasing(t, []float{2, 1})
+//    assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    assert.IsIncreasing(t, []int{1, 2, 3})
+//    assert.IsIncreasing(t, []float{1, 2})
+//    assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasing(t, []int{1, 1, 2})
+//    assert.IsNonDecreasing(t, []float{1, 2})
+//    assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasing(t, []int{2, 1, 1})
+//    assert.IsNonIncreasing(t, []float{2, 1})
+//    assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    assert.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Less asserts that the first element is less than the second
+//
+//    assert.Less(t, 1, 2)
+//    assert.Less(t, float64(1), float64(2))
+//    assert.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Less(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//    assert.LessOrEqual(t, 1, 2)
+//    assert.LessOrEqual(t, 2, 2)
+//    assert.LessOrEqual(t, "a", "b")
+//    assert.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//    assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//    assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//    assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//    assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//    assert.Lessf(t, 1, 2, "error message %s", "formatted")
+//    assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//    assert.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//    assert.Negative(t, -1)
+//    assert.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    assert.Negativef(t, -1, "error message %s", "formatted")
+//    assert.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//    assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Never(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//    assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Neverf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    assert.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    assert.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoError(t, err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if assert.NoErrorf(t, err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContains(t, "Hello World", "Earth")
+//    assert.NotContains(t, ["Hello", "World"], "Earth")
+//    assert.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmpty(t, obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    assert.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//    assert.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//    assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    assert.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    assert.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  assert.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//    assert.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSame(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//    assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSamef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//   assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithError(t, errString, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//   assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithErrorf(t, errString, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//    assert.Positive(t, 1)
+//    assert.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    assert.Positivef(t, 1, "error message %s", "formatted")
+//    assert.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  assert.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//    assert.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Same(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//    assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Samef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// True asserts that the specified value is true.
+//
+//    assert.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Truef asserts that the specified value is true.
+//
+//    assert.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,0 +1,6 @@
+{{.Comment}}
+func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
+	t.FailNow()
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,1471 @@
+/*
+* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
+* THIS FILE MUST NOT BE EDITED BY HAND
+ */
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Contains("Hello World", "World")
+//    a.Contains(["Hello", "World"], "World")
+//    a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//    a.Containsf("Hello World", "World", "error message %s", "formatted")
+//    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Empty(obj)
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  a.Emptyf(obj, "error message %s", "formatted")
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//    a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Error(err) {
+// 	   assert.Equal(t, expectedError, err)
+//   }
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.Errorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedErrorf, err)
+//   }
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//    a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//    a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//    a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//    a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//    a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//    a.Greater(2, 1)
+//    a.Greater(float64(2), float64(1))
+//    a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//    a.GreaterOrEqual(2, 1)
+//    a.GreaterOrEqual(2, 2)
+//    a.GreaterOrEqual("b", "a")
+//    a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//    a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//    a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//    a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//    a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//    a.Greaterf(2, 1, "error message %s", "formatted")
+//    a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//    a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//  a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//  a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//  a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//  a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//  a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//    a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//    a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+// 	 a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//    a.IsDecreasing([]int{2, 1, 0})
+//    a.IsDecreasing([]float{2, 1})
+//    a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    a.IsIncreasing([]int{1, 2, 3})
+//    a.IsIncreasing([]float{1, 2})
+//    a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasing([]int{1, 1, 2})
+//    a.IsNonDecreasing([]float{1, 2})
+//    a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    a.IsNonIncreasing([]int{2, 1, 1})
+//    a.IsNonIncreasing([]float{2, 1})
+//    a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//    a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//    a.Less(1, 2)
+//    a.Less(float64(1), float64(2))
+//    a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//    a.LessOrEqual(1, 2)
+//    a.LessOrEqual(2, 2)
+//    a.LessOrEqual("a", "b")
+//    a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//    a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//    a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//    a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//    a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//    a.Lessf(1, 2, "error message %s", "formatted")
+//    a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//    a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//    a.Negative(-1)
+//    a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    a.Negativef(-1, "error message %s", "formatted")
+//    a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//    a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//    a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//    a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoError(err) {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if a.NoErrorf(err, "error message %s", "formatted") {
+// 	   assert.Equal(t, expectedObj, actualObj)
+//   }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContains("Hello World", "Earth")
+//    a.NotContains(["Hello", "World"], "Earth")
+//    a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//    a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmpty(obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//  if a.NotEmptyf(obj, "error message %s", "formatted") {
+//    assert.Equal(t, "two", obj[1])
+//  }
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//    a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//    a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//    a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//    a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//  a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//  a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//    a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//    a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) contains not all
+// elements given in the specified subset(array, slice...).
+//
+//    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//   a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//   a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//    a.Positive(1)
+//    a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    a.Positivef(1, "error message %s", "formatted")
+//    a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  a.Regexp(regexp.MustCompile("start"), "it's starting")
+//  a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//  a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//    a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//    a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the specified list(array, slice...) contains all
+// elements given in the specified subset(array, slice...).
+//
+//    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//    a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//    a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zerof(a.t, i, msg, args...)
+}

--- a/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,29 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type tHelper interface {
+	Helper()
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -188,6 +188,7 @@ github.com/spf13/viper
 # github.com/stretchr/testify v1.7.0
 ## explicit
 github.com/stretchr/testify/assert
+github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
 # github.com/xanzy/ssh-agent v0.2.1


### PR DESCRIPTION
The usability of BPXE is still pretty limited as it can't
store or retrieve any data during process workflow.

Solution: sketch initial support for data objects

A newly introduced `data` package is responsible for working
with data. Container type is responsible for holding and providing
access to instances of ItemAware elements.

Speaking of which, the schema generator was extended to introduce ItemAware
and ItemAwareElement abstract types to match BPMN specification. For this to
happen, a modified XSchema specification was used to allow multiple type
extensions. Since this is not done for the purposes of schema validation,
but rather to enable code generation, I think this is acceptable.

This change also fixes an issue in the schema generator that
added `TextPayload` fields to structs of abstract types. This was
tripping up `xml.Decoder` as it was seeing a conflict of the payload
between the abstract type and the specific one.

Sequence flows now support accessing data objects through `getDataObject`
function with following caveats:

* Only a single-argument version of `getDataObject` is currently supported
  (two-argument version allows to refer to a parent process; since we don't
   support this yet, this has not been implemented)
* XPath engine does not yet support `getDataObject`. Some work has been done
  in this direction, but the test for this is currently being skipped as it
  doesn't work. The problem is (seemingly) in not being able to access the
  NodeSet returned by a function using the following path. I am trying to figure
  out if this has something to do with how xsel work and whether it can be
  made to work in this case.
* `getDataObject` does not currently distinguish between data objects, data
  object references and properties. This should be addressed to make it more
  precise.

The event subsystem is precipitated with the ability for certain messages to
carry data -- their structures have been augmented to support that. However,
this change does not implement this just yet. It is just a rough sketch to
work on in smaller, incremental fashion.