### PR TITLE
Problem: flow nodes require too many parameters

### DIFF
--- a/pkg/flow_node/activity/tests/boundary_test.go
+++ b/pkg/flow_node/activity/tests/boundary_test.go
@@ -68,7 +68,7 @@ func testBoundaryEvent(t *testing.T, boundary string, test func(visited map[stri
 				aTask.SetBody(func(task *task.Task, ctx context.Context) flow_node.Action {
 					select {
 					case <-ready:
-						return flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&task.T.Outgoing)}
+						return flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&task.Wiring.Outgoing)}
 					case <-ctx.Done():
 						return flow_node.CompleteAction{}
 					}


### PR DESCRIPTION
<flow_node>.New() methods are taking a huge number of
parameters and this hurts readability.

Solution: pass all this information in one struct

Most of these parameters are universally shared and were passed
through flow node implementations to `flow_node.New`.

Now, that structure is constructed prior to creation of a particular
flow node and a reference to it is passed to the flow node,
cutting down on a number of arguments required.

To celebrate this improvement, `flow_node.T` was renamed to a much
more fitting `flow_node.Wiring` (at least it's more informative than `T`)