### PR TITLE
Problem: expression engines in one package

### DIFF
--- a/pkg/expression/expr/expr_test.go
+++ b/pkg/expression/expr/expr_test.go
@@ -6,17 +6,19 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package expression
+package expr
 
 import (
 	"testing"
 
+	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/data"
+	"bpxe.org/pkg/expression"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExpr(t *testing.T) {
-	var engine Engine = NewExpr()
+	var engine expression.Engine = New()
 	compiled, err := engine.CompileExpression("a > 1")
 	assert.Nil(t, err)
 	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{
@@ -26,8 +28,20 @@ func TestExpr(t *testing.T) {
 	assert.True(t, result.(bool))
 }
 
+type dataObjects map[string]data.ItemAware
+
+func (d dataObjects) FindItemAwareById(id bpmn.IdRef) (itemAware data.ItemAware, found bool) {
+	itemAware, found = d[id]
+	return
+}
+
+func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware, found bool) {
+	itemAware, found = d[name]
+	return
+}
+
 func TestExpr_getDataObject(t *testing.T) {
-	var engine = NewExpr()
+	var engine = New()
 	container := data.NewContainer(nil)
 	container.Put(1)
 	var objs dataObjects = map[string]data.ItemAware{

--- a/pkg/expression/expr/package.go
+++ b/pkg/expression/expr/package.go
@@ -6,15 +6,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package main
-
-import "bpxe.org/cmd/bpxe/cmd"
-
-import (
-	_ "bpxe.org/pkg/expression/expr"
-	_ "bpxe.org/pkg/expression/xpath"
-)
-
-func main() {
-	cmd.Execute()
-}
+package expr

--- a/pkg/expression/package.go
+++ b/pkg/expression/package.go
@@ -6,5 +6,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-// Expression languages and their compilation/execution engines
 package expression

--- a/pkg/expression/xpath/package.go
+++ b/pkg/expression/xpath/package.go
@@ -6,15 +6,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package main
-
-import "bpxe.org/cmd/bpxe/cmd"
-
-import (
-	_ "bpxe.org/pkg/expression/expr"
-	_ "bpxe.org/pkg/expression/xpath"
-)
-
-func main() {
-	cmd.Execute()
-}
+// Expression languages and their compilation/execution engines
+package xpath

--- a/pkg/expression/xpath/xpath_test.go
+++ b/pkg/expression/xpath/xpath_test.go
@@ -6,18 +6,19 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package expression
+package xpath
 
 import (
 	"testing"
 
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/data"
+	"bpxe.org/pkg/expression"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestXPath(t *testing.T) {
-	var engine Engine = NewXPath()
+	var engine expression.Engine = New()
 	compiled, err := engine.CompileExpression("a > 1")
 	assert.Nil(t, err)
 	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{
@@ -42,7 +43,7 @@ func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware,
 func TestXPath_getDataObject(t *testing.T) {
 	// This funtionality doesn't quite work yet
 	t.SkipNow()
-	var engine = NewXPath()
+	var engine = New()
 	container := data.NewContainer(nil)
 	container.Put(data.XMLSource(`<tag attr="val"/>`))
 	var objs dataObjects = map[string]data.ItemAware{

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -17,6 +17,8 @@ import (
 	"bpxe.org/pkg/process"
 	"bpxe.org/pkg/tracing"
 	"github.com/stretchr/testify/require"
+
+	_ "bpxe.org/pkg/expression/expr"
 )
 
 var testCondExpr bpmn.Definitions

--- a/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
@@ -20,6 +20,8 @@ import (
 	"bpxe.org/pkg/tracing"
 
 	"github.com/stretchr/testify/assert"
+
+	_ "bpxe.org/pkg/expression/expr"
 )
 
 var testExclusiveGateway bpmn.Definitions

--- a/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
+++ b/pkg/flow_node/gateway/inclusive/inclusive_gateway.go
@@ -19,6 +19,8 @@ import (
 	"bpxe.org/pkg/id"
 	"bpxe.org/pkg/sequence_flow"
 	"bpxe.org/pkg/tracing"
+
+	_ "bpxe.org/pkg/expression/expr"
 )
 
 type NoEffectiveSequenceFlows struct {

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -19,6 +19,8 @@ import (
 	"bpxe.org/pkg/tracing"
 
 	"github.com/stretchr/testify/assert"
+
+	_ "bpxe.org/pkg/expression/expr"
 )
 
 var testParallelGateway bpmn.Definitions


### PR DESCRIPTION
This is not great because this way we always need to
get all their dependencies if we want *any* of the engines.

It's also aesthetically not very pleasing (`expression.NewExpr`
vs `expr.New`, etc.)

Solution: split them into separate packages

Please note that you'd need to import these packages
explicitly for the side effect of their registration in
`expression` (so that `expression.GetEngine` can find them)