### PR TITLE
Problem: process instance cancellation

### DIFF
--- a/cmd/bpxe/cmd/execute.go
+++ b/cmd/bpxe/cmd/execute.go
@@ -51,7 +51,7 @@ var executeCmd = &cobra.Command{
 			proc := process.New(processElement, &document)
 			if instance, err := proc.Instantiate(); err == nil {
 				traces := instance.Tracer.Subscribe()
-				err := instance.Run()
+				err := instance.Start(context.Background())
 				if err != nil {
 					fmt.Printf("failed to run the instance: %s\n", err)
 				}

--- a/pkg/expression/expr/expr_test.go
+++ b/pkg/expression/expr/expr_test.go
@@ -9,6 +9,7 @@
 package expr
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/pkg/bpmn"
@@ -42,7 +43,7 @@ func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware,
 
 func TestExpr_getDataObject(t *testing.T) {
 	var engine = New()
-	container := data.NewContainer(nil)
+	container := data.NewContainer(context.Background(), nil)
 	container.Put(1)
 	var objs dataObjects = map[string]data.ItemAware{
 		"dataObject": container,

--- a/pkg/expression/xpath/xpath_test.go
+++ b/pkg/expression/xpath/xpath_test.go
@@ -9,6 +9,7 @@
 package xpath
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/pkg/bpmn"
@@ -44,7 +45,7 @@ func TestXPath_getDataObject(t *testing.T) {
 	// This funtionality doesn't quite work yet
 	t.SkipNow()
 	var engine = New()
-	container := data.NewContainer(nil)
+	container := data.NewContainer(context.Background(), nil)
 	container.Put(data.XMLSource(`<tag attr="val"/>`))
 	var objs dataObjects = map[string]data.ItemAware{
 		"dataObject": container,

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/internal"
@@ -32,7 +33,7 @@ func TestTrueFormalExpression(t *testing.T) {
 	proc := process.New(&processElement, &testCondExpr)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -71,7 +72,7 @@ func TestFalseFormalExpression(t *testing.T) {
 	proc := process.New(&processElement, &testCondExprFalse)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -119,7 +120,7 @@ func TestCondDataObject(t *testing.T) {
 					require.True(t, found)
 					itemAware.Put(k == cond)
 				}
-				err := instance.Run()
+				err := instance.Start(context.Background())
 				if err != nil {
 					t.Fatalf("failed to run the instance: %s", err)
 				}

--- a/pkg/flow/traces.go
+++ b/pkg/flow/traces.go
@@ -33,6 +33,12 @@ type FlowTerminationTrace struct {
 
 func (t FlowTerminationTrace) TraceInterface() {}
 
+type CancellationTrace struct {
+	FlowId id.Id
+}
+
+func (t CancellationTrace) TraceInterface() {}
+
 type CompletionTrace struct {
 	Node bpmn.FlowNodeInterface
 }

--- a/pkg/flow_node/activity/task/tests/task_test.go
+++ b/pkg/flow_node/activity/task/tests/task_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/internal"
@@ -31,7 +32,7 @@ func TestTask(t *testing.T) {
 	proc := process.New(&processElement, &testTask)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/activity/tests/boundary_test.go
+++ b/pkg/flow_node/activity/tests/boundary_test.go
@@ -55,7 +55,7 @@ func testBoundaryEvent(t *testing.T, boundary string, test func(visited map[stri
 	ready := make(chan bool)
 
 	// explicit tracer
-	tracer := tracing.NewTracer()
+	tracer := tracing.NewTracer(context.Background())
 	// this gives us some room when instance starts up
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 
@@ -80,7 +80,7 @@ func testBoundaryEvent(t *testing.T, boundary string, test func(visited map[stri
 			t.Fatalf("failed to get the flow node element for `task`")
 		}
 
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/catch/catch_event.go
+++ b/pkg/flow_node/event/catch/catch_event.go
@@ -9,10 +9,13 @@
 package catch
 
 import (
+	"context"
+
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/flow/flow_interface"
 	"bpxe.org/pkg/flow_node"
+	"bpxe.org/pkg/tracing"
 )
 
 type message interface {
@@ -41,7 +44,8 @@ type Node struct {
 	matchedEvents   []bool
 }
 
-func New(wiring *flow_node.Wiring, catchEvent *bpmn.CatchEvent, instanceBuilder event.InstanceBuilder) (node *Node, err error) {
+func New(ctx context.Context, wiring *flow_node.Wiring, catchEvent *bpmn.CatchEvent,
+	instanceBuilder event.InstanceBuilder) (node *Node, err error) {
 	eventDefinitions := catchEvent.EventDefinitions()
 	eventInstances := make([]event.Instance, len(eventDefinitions))
 
@@ -58,7 +62,8 @@ func New(wiring *flow_node.Wiring, catchEvent *bpmn.CatchEvent, instanceBuilder 
 		eventInstances:  eventInstances,
 		matchedEvents:   make([]bool, len(eventDefinitions)),
 	}
-	go node.runner()
+	sender := node.Tracer.RegisterSender()
+	go node.runner(ctx, sender)
 	err = node.EventEgress.RegisterProcessEventConsumer(node)
 	if err != nil {
 		return
@@ -66,49 +71,56 @@ func New(wiring *flow_node.Wiring, catchEvent *bpmn.CatchEvent, instanceBuilder 
 	return
 }
 
-func (node *Node) runner() {
+func (node *Node) runner(ctx context.Context, sender tracing.SenderHandle) {
+	defer sender.Done()
+
 loop:
 	for {
-		msg := <-node.runnerChannel
-		switch m := msg.(type) {
-		case processEventMessage:
-			if node.activated {
-				if len(node.eventInstances) == 0 {
-					//lint:ignore SA4006 not sure why it's complaining, `ok` is used
-					//nolint:staticcheck
-					if _, ok := m.event.(event.NoneEvent); ok {
-						goto matched
-					}
-				} else {
-					for i, instance := range node.eventInstances {
-						if m.event.MatchesEventInstance(instance) {
-							node.matchedEvents[i] = true
+		select {
+		case msg := <-node.runnerChannel:
+			switch m := msg.(type) {
+			case processEventMessage:
+				if node.activated {
+					if len(node.eventInstances) == 0 {
+						//lint:ignore SA4006 not sure why it's complaining, `ok` is used
+						//nolint:staticcheck
+						if _, ok := m.event.(event.NoneEvent); ok {
 							goto matched
 						}
+					} else {
+						for i, instance := range node.eventInstances {
+							if m.event.MatchesEventInstance(instance) {
+								node.matchedEvents[i] = true
+								goto matched
+							}
+						}
 					}
-				}
-				continue loop
-			matched:
-				node.Tracer.Trace(EventObservedTrace{Node: node.element, Event: m.event})
-				for _, matched := range node.matchedEvents {
-					if !matched && node.element.ParallelMultiple() {
-						continue loop
+					continue loop
+				matched:
+					node.Tracer.Trace(EventObservedTrace{Node: node.element, Event: m.event})
+					for _, matched := range node.matchedEvents {
+						if !matched && node.element.ParallelMultiple() {
+							continue loop
+						}
 					}
+					awaitingActions := node.awaitingActions
+					for _, actionChan := range awaitingActions {
+						actionChan <- flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&node.Outgoing)}
+					}
+					node.awaitingActions = make([]chan flow_node.Action, 0)
+					node.activated = false
 				}
-				awaitingActions := node.awaitingActions
-				for _, actionChan := range awaitingActions {
-					actionChan <- flow_node.FlowAction{SequenceFlows: flow_node.AllSequenceFlows(&node.Outgoing)}
+			case nextActionMessage:
+				if !node.activated {
+					node.activated = true
+					node.Tracer.Trace(ActiveListeningTrace{Node: node.element})
 				}
-				node.awaitingActions = make([]chan flow_node.Action, 0)
-				node.activated = false
+				node.awaitingActions = append(node.awaitingActions, m.response)
+			default:
 			}
-		case nextActionMessage:
-			if !node.activated {
-				node.activated = true
-				node.Tracer.Trace(ActiveListeningTrace{Node: node.element})
-			}
-			node.awaitingActions = append(node.awaitingActions, m.response)
-		default:
+		case <-ctx.Done():
+			node.Tracer.Trace(flow_node.CancellationTrace{Node: node.element})
+			return
 		}
 	}
 }

--- a/pkg/flow_node/event/catch/tests/catch_event_test.go
+++ b/pkg/flow_node/event/catch/tests/catch_event_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/xml"
 	"testing"
 
@@ -98,11 +99,11 @@ func testEvent(t *testing.T, filename string, nodeId string, eventInstanceBuilde
 		proc.SetEventInstanceBuilder(eventInstanceBuilder)
 	}
 
-	tracer := tracing.NewTracer()
+	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 64))
 
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/end/end_event.go
+++ b/pkg/flow_node/event/end/end_event.go
@@ -9,6 +9,8 @@
 package end
 
 import (
+	"context"
+
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/flow/flow_interface"
@@ -35,7 +37,7 @@ type Node struct {
 	startEventsActivated []*bpmn.StartEvent
 }
 
-func New(wiring *flow_node.Wiring, endEvent *bpmn.EndEvent) (node *Node, err error) {
+func New(ctx context.Context, wiring *flow_node.Wiring, endEvent *bpmn.EndEvent) (node *Node, err error) {
 	node = &Node{
 		Wiring:               wiring,
 		element:              endEvent,
@@ -44,33 +46,41 @@ func New(wiring *flow_node.Wiring, endEvent *bpmn.EndEvent) (node *Node, err err
 		runnerChannel:        make(chan message, len(wiring.Incoming)*2+1),
 		startEventsActivated: make([]*bpmn.StartEvent, 0),
 	}
-	go node.runner()
+	sender := node.Tracer.RegisterSender()
+	go node.runner(ctx, sender)
 	return
 }
 
-func (node *Node) runner() {
-	for {
-		msg := <-node.runnerChannel
-		switch m := msg.(type) {
-		case nextActionMessage:
-			if !node.activated {
-				node.activated = true
-			}
-			// If the node already completed, then we essentially fuse it
-			if node.completed {
-				m.response <- flow_node.CompleteAction{}
-				continue
-			}
+func (node *Node) runner(ctx context.Context, sender tracing.SenderHandle) {
+	defer sender.Done()
 
-			if _, err := node.EventIngress.ConsumeProcessEvent(
-				event.MakeEndEvent(node.element),
-			); err == nil {
-				node.completed = true
-				m.response <- flow_node.CompleteAction{}
-			} else {
-				node.Wiring.Tracer.Trace(tracing.ErrorTrace{Error: err})
+	for {
+		select {
+		case msg := <-node.runnerChannel:
+			switch m := msg.(type) {
+			case nextActionMessage:
+				if !node.activated {
+					node.activated = true
+				}
+				// If the node already completed, then we essentially fuse it
+				if node.completed {
+					m.response <- flow_node.CompleteAction{}
+					continue
+				}
+
+				if _, err := node.EventIngress.ConsumeProcessEvent(
+					event.MakeEndEvent(node.element),
+				); err == nil {
+					node.completed = true
+					m.response <- flow_node.CompleteAction{}
+				} else {
+					node.Wiring.Tracer.Trace(tracing.ErrorTrace{Error: err})
+				}
+			default:
 			}
-		default:
+		case <-ctx.Done():
+			node.Tracer.Trace(flow_node.CancellationTrace{Node: node.element})
+			return
 		}
 	}
 }

--- a/pkg/flow_node/event/end/tests/end_event_test.go
+++ b/pkg/flow_node/event/end/tests/end_event_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/internal"
@@ -31,7 +32,7 @@ func TestEndEvent(t *testing.T) {
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/start/tests/start_event_test.go
+++ b/pkg/flow_node/event/start/tests/start_event_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/internal"
@@ -31,7 +32,7 @@ func TestStartEvent(t *testing.T) {
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -9,6 +9,7 @@
 package flow_node
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestNewFlowNode(t *testing.T) {
 				&flowNode.(*bpmn.ParallelGateway).FlowNode,
 				event.VoidProcessEventConsumer{},
 				event.VoidProcessEventSource{},
-				tracing.NewTracer(), NewLockedFlowNodeMapping(),
+				tracing.NewTracer(context.Background()), NewLockedFlowNodeMapping(),
 				&waitGroup,
 			)
 			assert.Nil(t, err)

--- a/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
@@ -44,7 +44,7 @@ func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...ev
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Errorf("failed to run the instance: %s", err)
 			return

--- a/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestExclusiveGateway(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -84,7 +85,7 @@ func TestExclusiveGatewayWithDefault(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayWithDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -134,7 +135,7 @@ func TestExclusiveGatewayWithNoDefault(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayWithNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -186,7 +187,7 @@ func TestExclusiveGatewayIncompleteJoin(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -31,10 +32,10 @@ func init() {
 func TestInclusiveGateway(t *testing.T) {
 	processElement := (*testInclusiveGateway.Processes())[0]
 	proc := process.New(&processElement, &testInclusiveGateway)
-	tracer := tracing.NewTracer()
+	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -87,10 +88,10 @@ func init() {
 func TestInclusiveGatewayDefault(t *testing.T) {
 	processElement := (*testInclusiveGatewayDefault.Processes())[0]
 	proc := process.New(&processElement, &testInclusiveGatewayDefault)
-	tracer := tracing.NewTracer()
+	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -146,7 +147,7 @@ func TestInclusiveGatewayNoDefault(t *testing.T) {
 	proc := process.New(&processElement, &testInclusiveGatewayNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"bpxe.org/internal"
@@ -34,7 +35,7 @@ func TestParallelGateway(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -84,7 +85,7 @@ func TestParallelGatewayMtoN(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayMtoN)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -133,7 +134,7 @@ func TestParallelGatewayNtoM(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayNtoM)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -183,7 +184,7 @@ func TestParallelGatewayIncompleteJoin(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Run()
+		err := instance.Start(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/traces.go
+++ b/pkg/flow_node/traces.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package flow_node
+
+import (
+	"bpxe.org/pkg/bpmn"
+)
+
+type CancellationTrace struct {
+	Node bpmn.FlowNodeInterface
+}
+
+func (t CancellationTrace) TraceInterface() {}
+
+type NewFlowNodeTrace struct {
+	Node bpmn.FlowNodeInterface
+}
+
+func (t NewFlowNodeTrace) TraceInterface() {}

--- a/pkg/id/id.go
+++ b/pkg/id/id.go
@@ -9,12 +9,14 @@
 package id
 
 import (
+	"context"
+
 	"bpxe.org/pkg/tracing"
 )
 
 type GeneratorBuilder interface {
-	NewIdGenerator(tracer *tracing.Tracer) (Generator, error)
-	RestoreIdGenerator(serialized []byte, tracer *tracing.Tracer) (Generator, error)
+	NewIdGenerator(ctx context.Context, tracer *tracing.Tracer) (Generator, error)
+	RestoreIdGenerator(ctx context.Context, serialized []byte, tracer *tracing.Tracer) (Generator, error)
 }
 
 type Generator interface {


### PR DESCRIPTION
It's currently next to impossible to cancel process
instance.

Solution: pass context.Context around

This includes not only flow nodes, but also flows and tracer.

Tracer interface has been augmented to allow for sender registration.
This registration will prevent Tracer from shutting down before all
senders shut down themselves by calling `SenderHandle.Done()`

Also, `process/instance.Run` was renamed to `process/instance.Start`
to describe its behaviour more precisely.