### PR TITLE
Problem: ItemAware interface can't respect context

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -98,13 +98,20 @@ type ItemAware interface {
 	// Get returns a channel that will eventually return the data item
 	//
 	// If item is in an unavailable state (see Unavailable),
-	// this channel will not send anything until the item becomes available
-	Get() <-chan Item
+	// this channel will not send anything until the item becomes available.
+	//
+	// If context is cancelled while sending in a request for data,
+	// a nil channel will be returned.
+	Get(ctx context.Context) <-chan Item
 	// Put sends a request to update the item
 	//
 	// If item is in an unavailable state (see Unavailable),
-	// the data will not update until the item becomes available
-	Put(Item)
+	// the data will not update until the item becomes available,
+	// at which time, the returned channel will be closed.
+	//
+	// If context is cancelled while sending in a request for data,
+	// a nil channel will be returned.
+	Put(ctx context.Context, item Item) <-chan struct{}
 }
 
 // ItemAwareLocator interface describes a way to find ItemAware

--- a/pkg/expression/engines.go
+++ b/pkg/expression/engines.go
@@ -9,24 +9,25 @@
 package expression
 
 import (
+	"context"
 	"sync"
 )
 
 var enginesLock sync.RWMutex
-var enginesMap = make(map[string]func() Engine)
+var enginesMap = make(map[string]func(ctx context.Context) Engine)
 
-func RegisterEngine(url string, engine func() Engine) {
+func RegisterEngine(url string, engine func(ctx context.Context) Engine) {
 	enginesLock.Lock()
 	enginesMap[url] = engine
 	enginesLock.Unlock()
 }
 
-func GetEngine(url string) (engine Engine) {
+func GetEngine(ctx context.Context, url string) (engine Engine) {
 	enginesLock.RLock()
 	if engineConstructor, ok := enginesMap[url]; ok {
-		engine = engineConstructor()
+		engine = engineConstructor(ctx)
 	} else {
-		engine = enginesMap["http://www.w3.org/1999/XPath"]()
+		engine = enginesMap["http://www.w3.org/1999/XPath"](ctx)
 	}
 	enginesLock.RUnlock()
 	return

--- a/pkg/expression/expr/expr_test.go
+++ b/pkg/expression/expr/expr_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestExpr(t *testing.T) {
-	var engine expression.Engine = New()
+	var engine expression.Engine = New(context.Background())
 	compiled, err := engine.CompileExpression("a > 1")
 	assert.Nil(t, err)
 	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{
@@ -42,9 +42,9 @@ func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware,
 }
 
 func TestExpr_getDataObject(t *testing.T) {
-	var engine = New()
+	var engine = New(context.Background())
 	container := data.NewContainer(context.Background(), nil)
-	container.Put(1)
+	container.Put(context.Background(), 1)
 	var objs dataObjects = map[string]data.ItemAware{
 		"dataObject": container,
 	}

--- a/pkg/expression/xpath/xpath_test.go
+++ b/pkg/expression/xpath/xpath_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestXPath(t *testing.T) {
-	var engine expression.Engine = New()
+	var engine expression.Engine = New(context.Background())
 	compiled, err := engine.CompileExpression("a > 1")
 	assert.Nil(t, err)
 	result, err := engine.EvaluateExpression(compiled, map[string]interface{}{
@@ -44,9 +44,9 @@ func (d dataObjects) FindItemAwareByName(name string) (itemAware data.ItemAware,
 func TestXPath_getDataObject(t *testing.T) {
 	// This funtionality doesn't quite work yet
 	t.SkipNow()
-	var engine = New()
+	var engine = New(context.Background())
 	container := data.NewContainer(context.Background(), nil)
-	container.Put(data.XMLSource(`<tag attr="val"/>`))
+	container.Put(context.Background(), data.XMLSource(`<tag attr="val"/>`))
 	var objs dataObjects = map[string]data.ItemAware{
 		"dataObject": container,
 	}

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -118,7 +118,7 @@ func TestCondDataObject(t *testing.T) {
 				for _, k := range []string{"cond1o", "cond2o"} {
 					itemAware, found := instance.FindItemAwareByName(k)
 					require.True(t, found)
-					itemAware.Put(k == cond)
+					itemAware.Put(context.Background(), k == cond)
 				}
 				err := instance.Start(context.Background())
 				if err != nil {


### PR DESCRIPTION
(Simply because it doesn't track its cancellation)

Solution: improve its interface to accept context

Also, while at it, it is now possible to track completion
of `ItemAware.Put` by waiting for the returned channel
to close.