### PR TITLE
Problem: process instantiation compliance

### DIFF
--- a/cmd/bpxe/cmd/execute.go
+++ b/cmd/bpxe/cmd/execute.go
@@ -51,7 +51,7 @@ var executeCmd = &cobra.Command{
 			proc := process.New(processElement, &document)
 			if instance, err := proc.Instantiate(); err == nil {
 				traces := instance.Tracer.Subscribe()
-				err := instance.Start(context.Background())
+				err := instance.StartAll(context.Background())
 				if err != nil {
 					fmt.Printf("failed to run the instance: %s\n", err)
 				}

--- a/pkg/event/consumer_test.go
+++ b/pkg/event/consumer_test.go
@@ -22,6 +22,12 @@ func (c erroringConsumer) ConsumeProcessEvent(ProcessEvent) (ConsumptionResult, 
 	return ConsumptionError, errors.New("some error")
 }
 
+type testEvent struct{}
+
+func (t testEvent) MatchesEventInstance(instance Instance) bool {
+	return false
+}
+
 func TestForwardProcessEvent(t *testing.T) {
 	someErroringConsumers := []ProcessEventConsumer{erroringConsumer{},
 		VoidProcessEventConsumer{}}
@@ -34,18 +40,18 @@ func TestForwardProcessEvent(t *testing.T) {
 	var err error
 	var ok bool
 
-	result, err = ForwardProcessEvent(MakeStartEvent(), &someErroringConsumers)
+	result, err = ForwardProcessEvent(testEvent{}, &someErroringConsumers)
 	assert.Equal(t, PartiallyConsumed, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)
 	assert.True(t, ok)
 	assert.Equal(t, 1, multiErr.Len())
 
-	result, err = ForwardProcessEvent(MakeStartEvent(), &noErroringConsumers)
+	result, err = ForwardProcessEvent(testEvent{}, &noErroringConsumers)
 	assert.Equal(t, Consumed, result)
 	assert.Nil(t, err)
 
-	result, err = ForwardProcessEvent(MakeStartEvent(), &allErroringConsumers)
+	result, err = ForwardProcessEvent(testEvent{}, &allErroringConsumers)
 	assert.Equal(t, ConsumptionError, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -17,18 +17,6 @@ type ProcessEvent interface {
 	MatchesEventInstance(Instance) bool
 }
 
-// Process has started
-type StartEvent struct{}
-
-func MakeStartEvent() StartEvent {
-	return StartEvent{}
-}
-
-func (ev StartEvent) MatchesEventInstance(instance Instance) bool {
-	// always false because there's no event definition that matches
-	return false
-}
-
 // Process has ended
 type EndEvent struct {
 	Element *bpmn.EndEvent

--- a/pkg/flow/tests/flow_test.go
+++ b/pkg/flow/tests/flow_test.go
@@ -33,7 +33,7 @@ func TestTrueFormalExpression(t *testing.T) {
 	proc := process.New(&processElement, &testCondExpr)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -72,7 +72,7 @@ func TestFalseFormalExpression(t *testing.T) {
 	proc := process.New(&processElement, &testCondExprFalse)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -120,7 +120,7 @@ func TestCondDataObject(t *testing.T) {
 					require.True(t, found)
 					itemAware.Put(context.Background(), k == cond)
 				}
-				err := instance.Start(context.Background())
+				err := instance.StartAll(context.Background())
 				if err != nil {
 					t.Fatalf("failed to run the instance: %s", err)
 				}

--- a/pkg/flow_node/activity/task/tests/task_test.go
+++ b/pkg/flow_node/activity/task/tests/task_test.go
@@ -32,7 +32,7 @@ func TestTask(t *testing.T) {
 	proc := process.New(&processElement, &testTask)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/activity/tests/boundary_test.go
+++ b/pkg/flow_node/activity/tests/boundary_test.go
@@ -80,7 +80,7 @@ func testBoundaryEvent(t *testing.T, boundary string, test func(visited map[stri
 			t.Fatalf("failed to get the flow node element for `task`")
 		}
 
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/catch/tests/catch_event_test.go
+++ b/pkg/flow_node/event/catch/tests/catch_event_test.go
@@ -103,7 +103,7 @@ func testEvent(t *testing.T, filename string, nodeId string, eventInstanceBuilde
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 64))
 
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/end/tests/end_event_test.go
+++ b/pkg/flow_node/event/end/tests/end_event_test.go
@@ -32,7 +32,7 @@ func TestEndEvent(t *testing.T) {
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/event/start/start_event.go
+++ b/pkg/flow_node/event/start/start_event.go
@@ -96,13 +96,12 @@ func (node *Node) runner(ctx context.Context, sender tracing.SenderHandle) {
 func (node *Node) ConsumeProcessEvent(
 	ev event.ProcessEvent,
 ) (result event.ConsumptionResult, err error) {
-	switch ev.(type) {
-	case *event.StartEvent:
-		node.runnerChannel <- startMessage{}
-	default:
-	}
 	result = event.Consumed
 	return
+}
+
+func (node *Node) Trigger() {
+	node.runnerChannel <- startMessage{}
 }
 
 func (node *Node) NextAction(flow_interface.T) chan flow_node.Action {

--- a/pkg/flow_node/event/start/tests/start_event_test.go
+++ b/pkg/flow_node/event/start/tests/start_event_test.go
@@ -32,7 +32,7 @@ func TestStartEvent(t *testing.T) {
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
@@ -44,7 +44,7 @@ func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...ev
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Errorf("failed to run the instance: %s", err)
 			return

--- a/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/exclusive/tests/exclusive_gateway_test.go
@@ -36,7 +36,7 @@ func TestExclusiveGateway(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -85,7 +85,7 @@ func TestExclusiveGatewayWithDefault(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayWithDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -135,7 +135,7 @@ func TestExclusiveGatewayWithNoDefault(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayWithNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -187,7 +187,7 @@ func TestExclusiveGatewayIncompleteJoin(t *testing.T) {
 	proc := process.New(&processElement, &testExclusiveGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -35,7 +35,7 @@ func TestInclusiveGateway(t *testing.T) {
 	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -91,7 +91,7 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
 	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -147,7 +147,7 @@ func TestInclusiveGatewayNoDefault(t *testing.T) {
 	proc := process.New(&processElement, &testInclusiveGatewayNoDefault)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}

--- a/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
+++ b/pkg/flow_node/gateway/parallel/tests/parallel_gateway_test.go
@@ -35,7 +35,7 @@ func TestParallelGateway(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGateway)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -85,7 +85,7 @@ func TestParallelGatewayMtoN(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayMtoN)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -134,7 +134,7 @@ func TestParallelGatewayNtoM(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayNtoM)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -184,7 +184,7 @@ func TestParallelGatewayIncompleteJoin(t *testing.T) {
 	proc := process.New(&processElement, &testParallelGatewayIncompleteJoin)
 	if instance, err := proc.Instantiate(); err == nil {
 		traces := instance.Tracer.Subscribe()
-		err := instance.Start(context.Background())
+		err := instance.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}


### PR DESCRIPTION
BPXE is currently non-compliant with how start events are
treated. Most importantly, it defines an off-specification
Start Event event type that it listens to. This is not what
it should be doing. There are listening scenarios for when
there are events defined, however explicit instantiation
should happen differently.

Solution: trigger direct process starts in instances

`process/Instance.StartWith` method specifies a start event
to be triggered within the instance. A complimentary `StartAll`
method triggers ALL start events.

`events.StartEvent` has been, therefore, removed.