### PR TITLE
Problem: explicit process instantiation only

### DIFF
--- a/pkg/bpmn/instantiators.go
+++ b/pkg/bpmn/instantiators.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package bpmn
+
+// InstantiatingFlowNodes returns a list of flow nodes that
+// can instantiate the process.
+func (p *Process) InstantiatingFlowNodes() (result []FlowNodeInterface) {
+	result = make([]FlowNodeInterface, 0)
+
+	for i := range *p.StartEvents() {
+		startEvent := &(*p.StartEvents())[i]
+		// Start event that observes some events
+		if len(startEvent.EventDefinitions()) > 0 {
+			result = append(result, startEvent)
+		}
+	}
+
+	for i := range *p.EventBasedGateways() {
+		gateway := &(*p.EventBasedGateways())[i]
+		// Event-based gateways with `instantiate` set to true
+		// and no incoming sequence flows
+		if gateway.Instantiate() && len(*gateway.Incomings()) == 0 {
+			result = append(result, gateway)
+		}
+	}
+
+	for i := range *p.ReceiveTasks() {
+		task := &(*p.ReceiveTasks())[i]
+		// Event-based gateways with `instantiate` set to true
+		// and no incoming sequence flows
+		if task.Instantiate() && len(*task.Incomings()) == 0 {
+			result = append(result, task)
+		}
+	}
+
+	return
+}

--- a/pkg/event/consumer.go
+++ b/pkg/event/consumer.go
@@ -34,15 +34,15 @@ const (
 )
 
 // Process event consumer interface
-type ProcessEventConsumer interface {
-	ConsumeProcessEvent(ProcessEvent) (ConsumptionResult, error)
+type Consumer interface {
+	ConsumeEvent(Event) (ConsumptionResult, error)
 }
 
 // Process event consumer that does nothing and returns EventConsumed result
-type VoidProcessEventConsumer struct{}
+type VoidConsumer struct{}
 
-func (t VoidProcessEventConsumer) ConsumeProcessEvent(
-	ev ProcessEvent,
+func (t VoidConsumer) ConsumeEvent(
+	ev Event,
 ) (result ConsumptionResult, err error) {
 	result = Consumed
 	return
@@ -54,10 +54,10 @@ func (t VoidProcessEventConsumer) ConsumeProcessEvent(
 // If none of them errors out, the result will be EventConsumed.
 // If some do, the result will be EventPartiallyConsumed and err will be *multierror.Errors
 // If all do, the result will be EventConsumptionError and err will be *multierror.Errors
-func ForwardProcessEvent(ev ProcessEvent, eventConsumers *[]ProcessEventConsumer) (result ConsumptionResult, err error) {
+func ForwardEvent(ev Event, eventConsumers *[]Consumer) (result ConsumptionResult, err error) {
 	var errors *multierror.Error
 	for _, consumer := range *eventConsumers {
-		result, consumerError := consumer.ConsumeProcessEvent(ev)
+		result, consumerError := consumer.ConsumeEvent(ev)
 		if result == ConsumptionError && consumerError != nil {
 			errors = multierror.Append(errors, consumerError)
 		}

--- a/pkg/event/consumer_test.go
+++ b/pkg/event/consumer_test.go
@@ -18,7 +18,7 @@ import (
 
 type erroringConsumer struct{}
 
-func (c erroringConsumer) ConsumeProcessEvent(ProcessEvent) (ConsumptionResult, error) {
+func (c erroringConsumer) ConsumeEvent(Event) (ConsumptionResult, error) {
 	return ConsumptionError, errors.New("some error")
 }
 
@@ -29,29 +29,29 @@ func (t testEvent) MatchesEventInstance(instance Instance) bool {
 }
 
 func TestForwardProcessEvent(t *testing.T) {
-	someErroringConsumers := []ProcessEventConsumer{erroringConsumer{},
-		VoidProcessEventConsumer{}}
-	noErroringConsumers := []ProcessEventConsumer{VoidProcessEventConsumer{},
-		VoidProcessEventConsumer{}}
-	allErroringConsumers := []ProcessEventConsumer{erroringConsumer{},
+	someErroringConsumers := []Consumer{erroringConsumer{},
+		VoidConsumer{}}
+	noErroringConsumers := []Consumer{VoidConsumer{},
+		VoidConsumer{}}
+	allErroringConsumers := []Consumer{erroringConsumer{},
 		erroringConsumer{}}
 	var result ConsumptionResult
 	var multiErr *multierror.Error
 	var err error
 	var ok bool
 
-	result, err = ForwardProcessEvent(testEvent{}, &someErroringConsumers)
+	result, err = ForwardEvent(testEvent{}, &someErroringConsumers)
 	assert.Equal(t, PartiallyConsumed, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)
 	assert.True(t, ok)
 	assert.Equal(t, 1, multiErr.Len())
 
-	result, err = ForwardProcessEvent(testEvent{}, &noErroringConsumers)
+	result, err = ForwardEvent(testEvent{}, &noErroringConsumers)
 	assert.Equal(t, Consumed, result)
 	assert.Nil(t, err)
 
-	result, err = ForwardProcessEvent(testEvent{}, &allErroringConsumers)
+	result, err = ForwardEvent(testEvent{}, &allErroringConsumers)
 	assert.Equal(t, ConsumptionError, result)
 	assert.NotNil(t, err)
 	ok = errors.As(err, &multiErr)

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -13,7 +13,7 @@ import (
 	"bpxe.org/pkg/data"
 )
 
-type ProcessEvent interface {
+type Event interface {
 	MatchesEventInstance(Instance) bool
 }
 

--- a/pkg/event/fanout.go
+++ b/pkg/event/fanout.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package event
+
+import (
+	"sync"
+)
+
+// FanOut is a straightforward Consumer + Source, forwards all consumed
+// messages to all subscribers registered at it.
+type FanOut struct {
+	eventConsumersLock sync.RWMutex
+	eventConsumers     []Consumer
+}
+
+func NewFanOut() *FanOut {
+	return &FanOut{}
+}
+
+func (f *FanOut) ConsumeEvent(ev Event) (result ConsumptionResult, err error) {
+	f.eventConsumersLock.RLock()
+	result, err = ForwardEvent(ev, &f.eventConsumers)
+	f.eventConsumersLock.RUnlock()
+	return
+}
+
+func (f *FanOut) RegisterEventConsumer(ev Consumer) (err error) {
+	f.eventConsumersLock.Lock()
+	f.eventConsumers = append(f.eventConsumers, ev)
+	f.eventConsumersLock.Unlock()
+	return
+}

--- a/pkg/event/instance.go
+++ b/pkg/event/instance.go
@@ -34,3 +34,9 @@ func NewInstance(def bpmn.EventDefinitionInterface) Instance {
 type InstanceBuilder interface {
 	NewEventInstance(def bpmn.EventDefinitionInterface) Instance
 }
+
+type DefaultInstanceBuilder struct{}
+
+func (d DefaultInstanceBuilder) NewEventInstance(def bpmn.EventDefinitionInterface) Instance {
+	return NewInstance(def)
+}

--- a/pkg/flow_node/event/end/end_event.go
+++ b/pkg/flow_node/event/end/end_event.go
@@ -68,7 +68,7 @@ func (node *Node) runner(ctx context.Context, sender tracing.SenderHandle) {
 					continue
 				}
 
-				if _, err := node.EventIngress.ConsumeProcessEvent(
+				if _, err := node.EventIngress.ConsumeEvent(
 					event.MakeEndEvent(node.element),
 				); err == nil {
 					node.completed = true

--- a/pkg/flow_node/flow_node.go
+++ b/pkg/flow_node/flow_node.go
@@ -27,12 +27,13 @@ type Wiring struct {
 	Definitions  *bpmn.Definitions
 	Incoming     []sequence_flow.SequenceFlow
 	Outgoing     []sequence_flow.SequenceFlow
-	EventIngress event.ProcessEventConsumer
-	EventEgress  event.ProcessEventSource
+	EventIngress event.Consumer
+	EventEgress  event.Source
 	Tracer       *tracing.Tracer
 	Process      *bpmn.Process
 	*FlowNodeMapping
-	FlowWaitGroup *sync.WaitGroup
+	FlowWaitGroup        *sync.WaitGroup
+	EventInstanceBuilder event.InstanceBuilder
 }
 
 func sequenceFlows(process *bpmn.Process,
@@ -58,11 +59,12 @@ func sequenceFlows(process *bpmn.Process,
 func New(process *bpmn.Process,
 	definitions *bpmn.Definitions,
 	flowNode *bpmn.FlowNode,
-	eventIngress event.ProcessEventConsumer,
-	eventEgress event.ProcessEventSource,
+	eventIngress event.Consumer,
+	eventEgress event.Source,
 	tracer *tracing.Tracer,
 	flowNodeMapping *FlowNodeMapping,
 	flowWaitGroup *sync.WaitGroup,
+	eventInstanceBuilder event.InstanceBuilder,
 ) (node *Wiring, err error) {
 	incoming, err := sequenceFlows(process, definitions, flowNode.Incomings())
 	if err != nil {
@@ -82,16 +84,17 @@ func New(process *bpmn.Process,
 		ownId = *ownIdPtr
 	}
 	node = &Wiring{
-		Id:              ownId,
-		Definitions:     definitions,
-		Incoming:        incoming,
-		Outgoing:        outgoing,
-		EventIngress:    eventIngress,
-		EventEgress:     eventEgress,
-		Tracer:          tracer,
-		Process:         process,
-		FlowNodeMapping: flowNodeMapping,
-		FlowWaitGroup:   flowWaitGroup,
+		Id:                   ownId,
+		Definitions:          definitions,
+		Incoming:             incoming,
+		Outgoing:             outgoing,
+		EventIngress:         eventIngress,
+		EventEgress:          eventEgress,
+		Tracer:               tracer,
+		Process:              process,
+		FlowNodeMapping:      flowNodeMapping,
+		FlowWaitGroup:        flowWaitGroup,
+		EventInstanceBuilder: eventInstanceBuilder,
 	}
 	return
 }
@@ -116,16 +119,17 @@ func (wiring *Wiring) CloneFor(flowNode *bpmn.FlowNode) (result *Wiring, err err
 		ownId = *ownIdPtr
 	}
 	result = &Wiring{
-		Id:              ownId,
-		Definitions:     wiring.Definitions,
-		Incoming:        incoming,
-		Outgoing:        outgoing,
-		EventIngress:    wiring.EventIngress,
-		EventEgress:     wiring.EventEgress,
-		Tracer:          wiring.Tracer,
-		Process:         wiring.Process,
-		FlowNodeMapping: wiring.FlowNodeMapping,
-		FlowWaitGroup:   wiring.FlowWaitGroup,
+		Id:                   ownId,
+		Definitions:          wiring.Definitions,
+		Incoming:             incoming,
+		Outgoing:             outgoing,
+		EventIngress:         wiring.EventIngress,
+		EventEgress:          wiring.EventEgress,
+		Tracer:               wiring.Tracer,
+		Process:              wiring.Process,
+		FlowNodeMapping:      wiring.FlowNodeMapping,
+		FlowWaitGroup:        wiring.FlowWaitGroup,
+		EventInstanceBuilder: wiring.EventInstanceBuilder,
 	}
 	return
 }

--- a/pkg/flow_node/flow_node_test.go
+++ b/pkg/flow_node/flow_node_test.go
@@ -36,10 +36,11 @@ func TestNewFlowNode(t *testing.T) {
 			node, err := New(proc.(*bpmn.Process),
 				&defaultDefinitions,
 				&flowNode.(*bpmn.ParallelGateway).FlowNode,
-				event.VoidProcessEventConsumer{},
-				event.VoidProcessEventSource{},
+				event.VoidConsumer{},
+				event.VoidSource{},
 				tracing.NewTracer(context.Background()), NewLockedFlowNodeMapping(),
 				&waitGroup,
+				event.DefaultInstanceBuilder{},
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, 1, len(node.Incoming))

--- a/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
+++ b/pkg/flow_node/gateway/event_based/tests/event_based_gateway_test.go
@@ -39,7 +39,7 @@ func TestEventBasedGateway(t *testing.T) {
 	}, event.NewMessageEvent("Msg1", nil))
 }
 
-func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...event.ProcessEvent) {
+func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...event.Event) {
 	processElement := (*testDoc.Processes())[0]
 	proc := process.New(&processElement, &testDoc)
 	if instance, err := proc.Instantiate(); err == nil {
@@ -113,7 +113,7 @@ func testEventBasedGateway(t *testing.T, test func(map[string]int), events ...ev
 		}()
 
 		for _, evt := range events {
-			_, err := instance.ConsumeProcessEvent(evt)
+			_, err := instance.ConsumeEvent(evt)
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
+++ b/pkg/flow_node/gateway/inclusive/tests/inclusive_gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"bpxe.org/pkg/flow"
 	"bpxe.org/pkg/flow_node/gateway/inclusive"
 	"bpxe.org/pkg/process"
+	"bpxe.org/pkg/process/instance"
 	"bpxe.org/pkg/tracing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,8 +35,8 @@ func TestInclusiveGateway(t *testing.T) {
 	proc := process.New(&processElement, &testInclusiveGateway)
 	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
-	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.StartAll(context.Background())
+	if inst, err := proc.Instantiate(instance.WithTracer(tracer)); err == nil {
+		err := inst.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -73,7 +74,7 @@ func TestInclusiveGateway(t *testing.T) {
 				t.Logf("%#v", trace)
 			}
 		}
-		instance.Tracer.Unsubscribe(traces)
+		inst.Tracer.Unsubscribe(traces)
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}
@@ -90,8 +91,8 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 	proc := process.New(&processElement, &testInclusiveGatewayDefault)
 	tracer := tracing.NewTracer(context.Background())
 	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 32))
-	if instance, err := proc.Instantiate(process.WithTracer(tracer)); err == nil {
-		err := instance.StartAll(context.Background())
+	if inst, err := proc.Instantiate(instance.WithTracer(tracer)); err == nil {
+		err := inst.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -130,7 +131,7 @@ func TestInclusiveGatewayDefault(t *testing.T) {
 				t.Logf("%#v", trace)
 			}
 		}
-		instance.Tracer.Unsubscribe(traces)
+		inst.Tracer.Unsubscribe(traces)
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}
@@ -145,9 +146,9 @@ func init() {
 func TestInclusiveGatewayNoDefault(t *testing.T) {
 	processElement := (*testInclusiveGatewayNoDefault.Processes())[0]
 	proc := process.New(&processElement, &testInclusiveGatewayNoDefault)
-	if instance, err := proc.Instantiate(); err == nil {
-		traces := instance.Tracer.Subscribe()
-		err := instance.StartAll(context.Background())
+	if inst, err := proc.Instantiate(); err == nil {
+		traces := inst.Tracer.Subscribe()
+		err := inst.StartAll(context.Background())
 		if err != nil {
 			t.Fatalf("failed to run the instance: %s", err)
 		}
@@ -167,7 +168,7 @@ func TestInclusiveGatewayNoDefault(t *testing.T) {
 				t.Logf("%#v", trace)
 			}
 		}
-		instance.Tracer.Unsubscribe(traces)
+		inst.Tracer.Unsubscribe(traces)
 	} else {
 		t.Fatalf("failed to instantiate the process: %s", err)
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -9,33 +9,118 @@
 package model
 
 import (
+	"context"
+	"sync"
+
 	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/event"
 	"bpxe.org/pkg/id"
 	"bpxe.org/pkg/process"
+	"bpxe.org/pkg/tracing"
 )
 
 type Model struct {
-	Element   *bpmn.Definitions
-	processes []process.Process
+	Element              *bpmn.Definitions
+	processes            []process.Process
+	eventConsumersLock   sync.RWMutex
+	eventConsumers       []event.Consumer
+	idGeneratorBuilder   id.GeneratorBuilder
+	eventInstanceBuilder event.InstanceBuilder
+	tracer               *tracing.Tracer
 }
 
-func New(element *bpmn.Definitions) *Model {
-	return NewWithIdGenerator(element, id.DefaultIdGeneratorBuilder)
+type Option func(context.Context, *Model) context.Context
+
+func WithIdGenerator(builder id.GeneratorBuilder) Option {
+	return func(ctx context.Context, model *Model) context.Context {
+		model.idGeneratorBuilder = builder
+		return ctx
+	}
 }
 
-func NewWithIdGenerator(element *bpmn.Definitions, idGeneratorBuilder id.GeneratorBuilder) *Model {
+func WithEventInstanceBuilder(builder event.InstanceBuilder) Option {
+	return func(ctx context.Context, model *Model) context.Context {
+		model.eventInstanceBuilder = builder
+		return ctx
+	}
+}
+
+// WithContext will pass a given context to a new model
+// instead of implicitly generated one
+func WithContext(newCtx context.Context) Option {
+	return func(ctx context.Context, model *Model) context.Context {
+		return newCtx
+	}
+}
+
+// WithTracer overrides model's tracer
+func WithTracer(tracer *tracing.Tracer) Option {
+	return func(ctx context.Context, model *Model) context.Context {
+		model.tracer = tracer
+		return ctx
+	}
+}
+
+func New(element *bpmn.Definitions, options ...Option) *Model {
 	procs := element.Processes()
-	processes := make([]process.Process, len(*procs))
+	model := &Model{
+		Element: element,
+	}
+
+	ctx := context.Background()
+
+	for _, option := range options {
+		ctx = option(ctx, model)
+	}
+
+	if model.idGeneratorBuilder == nil {
+		model.idGeneratorBuilder = id.DefaultIdGeneratorBuilder
+	}
+
+	if model.eventInstanceBuilder == nil {
+		model.eventInstanceBuilder = event.DefaultInstanceBuilder{}
+	}
+
+	if model.tracer == nil {
+		model.tracer = tracing.NewTracer(ctx)
+	}
+
+	model.processes = make([]process.Process, len(*procs))
+
 	for i := range *procs {
-		processes[i] = process.Make(&(*procs)[i], element, idGeneratorBuilder)
+		model.processes[i] = process.Make(&(*procs)[i], element,
+			process.WithIdGenerator(model.idGeneratorBuilder),
+			process.WithEventIngress(model), process.WithEventEgress(model),
+			process.WithEventInstanceBuilder(model),
+			process.WithContext(ctx),
+			process.WithTracer(model.tracer),
+		)
 	}
-	return &Model{
-		Element:   element,
-		processes: processes,
-	}
+	return model
 }
 
-func (model *Model) Run() {
+func (model *Model) Run(ctx context.Context) (err error) {
+	// Setup process instantiation
+	for i := range *model.Element.Processes() {
+		instantiatingFlowNodes := (*model.Element.Processes())[i].InstantiatingFlowNodes()
+		for j := range instantiatingFlowNodes {
+			flowNode := instantiatingFlowNodes[j]
+
+			switch node := flowNode.(type) {
+			case *bpmn.StartEvent:
+				err = model.RegisterEventConsumer(newStartEventConsumer(ctx,
+					model.tracer,
+					&model.processes[i],
+					node, model.eventInstanceBuilder))
+				if err != nil {
+					return
+				}
+			case *bpmn.EventBasedGateway:
+			case *bpmn.ReceiveTask:
+			}
+		}
+	}
+	return
 }
 
 func (model *Model) FindProcessBy(f func(*process.Process) bool) (result *process.Process, found bool) {
@@ -47,4 +132,29 @@ func (model *Model) FindProcessBy(f func(*process.Process) bool) (result *proces
 		}
 	}
 	return
+}
+
+func (model *Model) ConsumeEvent(ev event.Event) (result event.ConsumptionResult, err error) {
+	model.eventConsumersLock.RLock()
+	// We're copying the list of consumers here to ensure that
+	// new consumers can subscribe during event forwarding
+	eventConsumers := model.eventConsumers
+	model.eventConsumersLock.RUnlock()
+	result, err = event.ForwardEvent(ev, &eventConsumers)
+	return
+}
+
+func (model *Model) RegisterEventConsumer(ev event.Consumer) (err error) {
+	model.eventConsumersLock.Lock()
+	model.eventConsumers = append(model.eventConsumers, ev)
+	model.eventConsumersLock.Unlock()
+	return
+}
+
+func (model *Model) NewEventInstance(def bpmn.EventDefinitionInterface) event.Instance {
+	if model.eventInstanceBuilder != nil {
+		return model.eventInstanceBuilder.NewEventInstance(def)
+	} else {
+		return event.NewInstance(def)
+	}
 }

--- a/pkg/model/start_event_consumer.go
+++ b/pkg/model/start_event_consumer.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package model
+
+import (
+	"context"
+	"sync"
+
+	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/event"
+	"bpxe.org/pkg/process"
+	"bpxe.org/pkg/process/instance"
+	"bpxe.org/pkg/tracing"
+)
+
+type startEventConsumer struct {
+	process                                *process.Process
+	parallel                               bool
+	eventInstances, originalEventInstances []event.Instance
+	ctx                                    context.Context
+	consumptionLock                        sync.Mutex
+	tracer                                 *tracing.Tracer
+	events                                 []event.Event
+	element                                bpmn.FlowNodeInterface
+}
+
+func newStartEventConsumer(
+	ctx context.Context,
+	tracer *tracing.Tracer,
+	process *process.Process,
+	startEvent *bpmn.StartEvent, builder event.InstanceBuilder) *startEventConsumer {
+	var evCap int
+	if startEvent.ParallelMultiple() {
+		evCap = len(startEvent.EventDefinitions())
+	} else {
+		evCap = 1
+	}
+	consumer := &startEventConsumer{
+		ctx:      ctx,
+		process:  process,
+		parallel: startEvent.ParallelMultiple(),
+		tracer:   tracer,
+		events:   make([]event.Event, 0, evCap),
+		element:  startEvent,
+	}
+	consumer.eventInstances = make([]event.Instance, len(startEvent.EventDefinitions()))
+	for k := range startEvent.EventDefinitions() {
+		consumer.eventInstances[k] = builder.NewEventInstance(startEvent.EventDefinitions()[k])
+	}
+	consumer.originalEventInstances = consumer.eventInstances
+	return consumer
+}
+
+func (s *startEventConsumer) ConsumeEvent(ev event.Event) (result event.ConsumptionResult, err error) {
+	s.consumptionLock.Lock()
+	defer s.consumptionLock.Unlock()
+	defer s.tracer.Trace(EventInstantiationAttemptedTrace{Event: ev, Element: s.element})
+
+	for i := range s.eventInstances {
+		if ev.MatchesEventInstance(s.eventInstances[i]) {
+			s.events = append(s.events, ev)
+			if !s.parallel {
+				goto instantiate
+			} else {
+				s.eventInstances[i] = s.eventInstances[len(s.eventInstances)-1]
+				s.eventInstances = s.eventInstances[0 : len(s.eventInstances)-1]
+				if len(s.eventInstances) == 0 {
+					s.eventInstances = s.originalEventInstances
+					goto instantiate
+				}
+			}
+			break
+		}
+	}
+	result = event.Consumed
+	return
+instantiate:
+	var inst *instance.Instance
+	inst, err = s.process.Instantiate(
+		instance.WithContext(s.ctx),
+		instance.WithTracer(s.tracer),
+	)
+	if err != nil {
+		result = event.ConsumptionError
+		return
+	}
+	for _, ev := range s.events {
+		result, err = inst.ConsumeEvent(ev)
+		if err != nil {
+			result = event.ConsumptionError
+			return
+		}
+	}
+	s.events = s.events[:0]
+	return
+}

--- a/pkg/model/tests/instantiation_test.go
+++ b/pkg/model/tests/instantiation_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 Aree Enterprises, Inc. and Contributors
+// Use of this software is governed by the Business Source License
+// included in the file LICENSE
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/LICENSE-Apache-2.0
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"bpxe.org/internal"
+	"bpxe.org/pkg/bpmn"
+	"bpxe.org/pkg/event"
+	"bpxe.org/pkg/flow"
+	"bpxe.org/pkg/model"
+	"bpxe.org/pkg/tracing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testStartEventInstantiation bpmn.Definitions
+
+func init() {
+	internal.LoadTestFile("testdata/instantiate_start_event.bpmn", testdata, &testStartEventInstantiation)
+}
+
+func TestStartEventInstantiation(t *testing.T) {
+	ctx := context.Background()
+	tracer := tracing.NewTracer(ctx)
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 128))
+	m := model.New(&testStartEventInstantiation, model.WithContext(ctx), model.WithTracer(tracer))
+	err := m.Run(ctx)
+	require.Nil(t, err)
+loop:
+	for {
+		select {
+		case trace := <-traces:
+			_, ok := trace.(flow.FlowTrace)
+			// Should not flow
+			require.False(t, ok)
+		default:
+			break loop
+		}
+	}
+	// Test simple event instantiation
+	_, err = m.ConsumeEvent(event.NewSignalEvent("sig1"))
+	require.Nil(t, err)
+loop1:
+	for {
+		trace := <-traces
+		switch trace := trace.(type) {
+		case flow.VisitTrace:
+			if idPtr, present := trace.Node.Id(); present {
+				if *idPtr == "sig1a" {
+					// we've reached the desired outcome
+					break loop1
+				}
+			}
+		default:
+			t.Logf("%#v", trace)
+		}
+	}
+}
+
+func TestMultipleStartEventInstantiation(t *testing.T) {
+	ctx := context.Background()
+	tracer := tracing.NewTracer(ctx)
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 128))
+	m := model.New(&testStartEventInstantiation, model.WithContext(ctx), model.WithTracer(tracer))
+	err := m.Run(ctx)
+	require.Nil(t, err)
+loop:
+	for {
+		select {
+		case trace := <-traces:
+			_, ok := trace.(flow.FlowTrace)
+			// Should not flow
+			require.False(t, ok)
+		default:
+			break loop
+		}
+	}
+	// Test multiple event instantiation
+	_, err = m.ConsumeEvent(event.NewSignalEvent("sig2"))
+	require.Nil(t, err)
+loop1:
+	for {
+		trace := <-traces
+		switch trace := trace.(type) {
+		case flow.VisitTrace:
+			if idPtr, present := trace.Node.Id(); present {
+				if *idPtr == "sig2_sig3a" {
+					// we've reached the desired outcome
+					break loop1
+				}
+			}
+		default:
+			t.Logf("%#v", trace)
+		}
+	}
+}
+
+func TestParallelMultipleStartEventInstantiation(t *testing.T) {
+	ctx := context.Background()
+	tracer := tracing.NewTracer(ctx)
+	traces := tracer.SubscribeChannel(make(chan tracing.Trace, 128))
+	m := model.New(&testStartEventInstantiation, model.WithContext(ctx), model.WithTracer(tracer))
+	err := m.Run(ctx)
+	require.Nil(t, err)
+loop:
+	for {
+		select {
+		case trace := <-traces:
+			_, ok := trace.(flow.FlowTrace)
+			// Should not flow
+			require.False(t, ok)
+		default:
+			break loop
+		}
+	}
+	// Test parallel multiple event instantiation
+	signalEvent := event.NewSignalEvent("sig2")
+	_, err = m.ConsumeEvent(signalEvent)
+	require.Nil(t, err)
+	sig3sent := false
+loop1:
+	for {
+		trace := <-traces
+		switch trace := trace.(type) {
+		case model.EventInstantiationAttemptedTrace:
+			if !sig3sent && signalEvent == trace.Event {
+				if idPtr, present := trace.Element.Id(); present && *idPtr == "ParallelMultipleStartEvent" {
+					_, err = m.ConsumeEvent(event.NewSignalEvent("sig3"))
+					require.Nil(t, err)
+					sig3sent = true
+				}
+			}
+		case flow.VisitTrace:
+			if idPtr, present := trace.Node.Id(); present {
+				if *idPtr == "sig2_and_sig3a" {
+					require.True(t, sig3sent)
+					// we've reached the desired outcome
+					break loop1
+				}
+			}
+		default:
+			t.Logf("%#v", trace)
+
+		}
+
+	}
+}

--- a/pkg/model/tests/package.go
+++ b/pkg/model/tests/package.go
@@ -6,16 +6,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package event
-
-type Source interface {
-	RegisterEventConsumer(Consumer) error
-}
-
-type VoidSource struct{}
-
-func (t VoidSource) RegisterEventConsumer(
-	consumer Consumer,
-) (err error) {
-	return
-}
+package tests

--- a/pkg/model/tests/testdata/instantiate_start_event.bpmn
+++ b/pkg/model/tests/testdata/instantiate_start_event.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1n7pd2d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.7.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+  <bpmn:process id="Process_17ixslg" isExecutable="true">
+    <bpmn:startEvent id="SignalStartEvent">
+      <bpmn:outgoing>Flow_1rnz2eg</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0rikp1k" signalRef="sig1" />
+    </bpmn:startEvent>
+    <bpmn:task id="sig1a" name="sig1a">
+      <bpmn:incoming>Flow_1rnz2eg</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1rnz2eg" sourceRef="SignalStartEvent" targetRef="sig1a" />
+    <bpmn:startEvent id="MultipleStartEvent">
+      <bpmn:outgoing>Flow_1psirta</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_16c89ob" signalRef="sig2" />
+      <bpmn:signalEventDefinition id="SignalEventDefinition_16c89oa" signalRef="sig3" />
+    </bpmn:startEvent>
+    <bpmn:task id="sig2_sig3a" name="sig2 or sig3">
+      <bpmn:incoming>Flow_1psirta</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1psirta" sourceRef="MultipleStartEvent" targetRef="sig2_sig3a" />
+    <bpmn:startEvent id="ParallelMultipleStartEvent" parallelMultiple="true">
+      <bpmn:outgoing>Flow_0qo7zwm</bpmn:outgoing>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0spzsje" signalRef="sig2" />
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0vvuqhu" signalRef="sig3" />
+    </bpmn:startEvent>
+    <bpmn:task id="sig2_and_sig3a" name="sig2 and sig3">
+      <bpmn:incoming>Flow_0qo7zwm</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0qo7zwm" sourceRef="ParallelMultipleStartEvent" targetRef="sig2_and_sig3a" />
+  </bpmn:process>
+  <bpmn:signal id="sig1" name="sig1" />
+  <bpmn:signal id="Signal_0ua1q75" name="Signal_1fj93gl" />
+  <bpmn:signal id="sig2" name="sig2" />
+  <bpmn:signal id="sig3" name="sig3" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_17ixslg">
+      <bpmndi:BPMNEdge id="Flow_1psirta_di" bpmnElement="Flow_1psirta">
+        <di:waypoint x="215" y="290" />
+        <di:waypoint x="270" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rnz2eg_di" bpmnElement="Flow_1rnz2eg">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qo7zwm_di" bpmnElement="Flow_0qo7zwm">
+        <di:waypoint x="215" y="400" />
+        <di:waypoint x="270" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1m9fa0l_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mbb9ew_di" bpmnElement="sig1a">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1gexgrc_di" bpmnElement="MultipleStartEvent">
+        <dc:Bounds x="179" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_111jy6v_di" bpmnElement="sig2_sig3a">
+        <dc:Bounds x="270" y="250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1o6fjq1_di" bpmnElement="ParallelMultipleStartEvent">
+        <dc:Bounds x="179" y="382" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14ll332_di" bpmnElement="sig2_and_sig3a">
+        <dc:Bounds x="270" y="360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/pkg/model/tests/testdata_test.go
+++ b/pkg/model/tests/testdata_test.go
@@ -6,16 +6,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package event
+package tests
 
-type Source interface {
-	RegisterEventConsumer(Consumer) error
-}
+import "embed"
 
-type VoidSource struct{}
-
-func (t VoidSource) RegisterEventConsumer(
-	consumer Consumer,
-) (err error) {
-	return
-}
+//go:embed testdata
+var testdata embed.FS

--- a/pkg/model/traces.go
+++ b/pkg/model/traces.go
@@ -6,24 +6,16 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package catch
+package model
 
 import (
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/event"
 )
 
-type ActiveListeningTrace struct {
-	Node *bpmn.CatchEvent
+type EventInstantiationAttemptedTrace struct {
+	Event   event.Event
+	Element bpmn.FlowNodeInterface
 }
 
-func (t ActiveListeningTrace) TraceInterface() {}
-
-// EventObservedTrace signals the fact that a particular event
-// has been in fact observed by the node
-type EventObservedTrace struct {
-	Node  *bpmn.CatchEvent
-	Event event.Event
-}
-
-func (t EventObservedTrace) TraceInterface() {}
+func (e EventInstantiationAttemptedTrace) TraceInterface() {}

--- a/pkg/process/instance/package.go
+++ b/pkg/process/instance/package.go
@@ -6,16 +6,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/LICENSE-Apache-2.0
 
-package event
-
-type Source interface {
-	RegisterEventConsumer(Consumer) error
-}
-
-type VoidSource struct{}
-
-func (t VoidSource) RegisterEventConsumer(
-	consumer Consumer,
-) (err error) {
-	return
-}
+package instance

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -15,6 +15,7 @@ import (
 	"bpxe.org/internal"
 	"bpxe.org/pkg/bpmn"
 	"bpxe.org/pkg/flow_node"
+	"bpxe.org/pkg/process/instance"
 	"bpxe.org/pkg/tracing"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,9 +31,9 @@ func init() {
 func TestExplicitInstantiation(t *testing.T) {
 	if proc, found := sampleDoc.FindBy(bpmn.ExactId("sample")); found {
 		process := New(proc.(*bpmn.Process), &defaultDefinitions)
-		instance, err := process.Instantiate()
+		inst, err := process.Instantiate()
 		assert.Nil(t, err)
-		assert.NotNil(t, instance)
+		assert.NotNil(t, inst)
 	} else {
 		t.Fatalf("Can't find process `sample`")
 	}
@@ -47,9 +48,9 @@ func TestCancellation(t *testing.T) {
 		tracer := tracing.NewTracer(ctx)
 		traces := tracer.SubscribeChannel(make(chan tracing.Trace, 128))
 
-		instance, err := process.Instantiate(WithContext(ctx), WithTracer(tracer))
+		inst, err := process.Instantiate(instance.WithContext(ctx), instance.WithTracer(tracer))
 		assert.Nil(t, err)
-		assert.NotNil(t, instance)
+		assert.NotNil(t, inst)
 
 		cancel()
 


### PR DESCRIPTION
Currently, a process can be only instantiated explicitly, but
this is not very useful for situations when processes need to be
triggered.

Solution: start implementing further instantiation semantics
from BPMN specification.

This is a fairly big change. Firstly, events have been extracted
from process scope into a model scope (where they should have belonged
in the first place, in fact) and renamed from `ProcessEvent` to `Event`.

Secondly, a running model (one started by `model/Model.Run`) will
now register event consumers that will look for events defined in
flow nodes that are eligible for process instantiation (see
`bpmn/Process.InstantiatingFlowNodes`) and will instantiate a process
if events do match. It's currently only implemented for Start Events
and needs to be extended to Event-Based Gateways as well as Receive Tasks
(which are not yet implemented).

`process/Instance` have been extracted to `process/instance/Instance` mostly
to separate processes and instances logically, but also to allow the same
names for `WithXXX` constructor options to allow passage of contexts and
other information.

It is important to note here that the way event egress and ingress is done
for flow nodes has changed a bit: instance itself is now supposed to
consume events from the model and forward them to flow nodes; flow nodes, however,
send out their events to the model. This allows to specify different entry
points for events. So, publishing into an instance will only send an event
into its subscribers; publishing into a model will send it to all subscribers.