### PR TITLE
Problem: activity active boundary signalling

### DIFF
--- a/pkg/flow_node/activity/interface.go
+++ b/pkg/flow_node/activity/interface.go
@@ -15,9 +15,6 @@ import (
 // Activity is a generic interface to flow nodes that are activities
 type Activity interface {
 	flow_node.FlowNodeInterface
-	// ActiveBoundary returns a channel that signals `true` when activity becomes
-	// active and, subsequently, `false` when it's over.
-	ActiveBoundary() <-chan bool
 	// Cancel initiates a cancellation of activity and returns a channel
 	// that will signal a boolean (`true` if cancellation was successful,
 	// `false` otherwise)


### PR DESCRIPTION
Activity harness delegates signalling of active boundary
to the activity itself. Not only it's cumbersome and likely
buggy, it likely makes little sense if you think about
other features of activities, such as loop characteristics.

Current implementation suggests that in a loop characteristic,
every iteration of the loop will enter and exit the activity
boundary for the purpose of observing boundary-attached events,
which doesn't make a whole lot of sense, as the loop-characterized
activity displays as a single element in notation.

Solution: open and close boundary in the harness

This way, the entire activity, regardless of its loop characteristics,
is covered by the boundary.

While I can't quite pinpoint how BPMN specification defines this
aspect, if you look at Table 10.29, `behavior` attribute, you can
notice this: "Any thrown Events can be caught by boundary Events
on the Multi-instance Activity". This hints at the fact that there's
one boundary, not multiple boundaries.