### PR TITLE
Problem: impossible clock logic in host's change monitor

### DIFF
--- a/pkg/clock/host_generic.go
+++ b/pkg/clock/host_generic.go
@@ -19,13 +19,13 @@ const hostForwardDriftTolerance = 3 * time.Second
 
 func changeMonitor(ctx context.Context, changes chan time.Time) (err error) {
 	go func(ctx context.Context) {
-		t := time.Now()
 		for {
+			t := time.Now()
 			select {
 			case <-ctx.Done():
 				return
 			case t1 := <-time.After(time.Second * 1):
-				if t1.Before(t1) {
+				if t1.Before(t) {
 					// backward drift
 					changes <- t1
 				} else if t1.Sub(t).Nanoseconds() > hostForwardDriftTolerance.Nanoseconds() {


### PR DESCRIPTION
There's a test that tests whether a certain time is before
itself. That's clearly impossible.

Solution: check whether it's before previously known time

While we're at it, update current time on every iteration of the loop.

The reason for this mishap is that this piece of code is not
well tested yet (since it can be only tested manually)

Addresses #64