### PR TITLE
Problem: `clock.Mock.After` doesn't unlock

### DIFF
--- a/pkg/clock/mock.go
+++ b/pkg/clock/mock.go
@@ -53,6 +53,7 @@ func (m *Mock) After(duration time.Duration) <-chan time.Time {
 	m.Lock()
 	ch := make(chan time.Time, 1)
 	if duration.Nanoseconds() <= 0 {
+		m.Unlock()
 		ch <- m.now
 		close(ch)
 		return ch


### PR DESCRIPTION
When `After` takes the fast path of returning
when the duration is zero or negative, it doesn't
unlock its mutex.

Solution: unlock it (just like `Until` does)

Addresses #68