### PR TITLE
Problem: bad advice on testing clock changes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,70 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/alpine312"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/bpxe"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/pkg/clock/manual_test/main.go
+++ b/pkg/clock/manual_test/main.go
@@ -13,11 +13,13 @@
 //
 // $ CGO_ENABLED=0 go build -o bin ./pkg/clock/manual_test/
 //
-// And run ./bin/manual_test, preferably in a container where you can change
-// date:
+// And run ./bin/manual_test, preferably in a virtual machine:
 //
-// $ docker run --cap-add=SYS_TIME -v $(pwd):/test -w /test -ti ubuntu:latest
-// # ./bin/manual_test &
+// $ vagrant up
+// $ vagrant ssh
+// ...
+// $ sudo -s
+// # /bpxe/bin/manual_test &
 // ...
 // # date -s 10:00
 // # date -s 11:00
@@ -41,7 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error: %s", err.Error())
 	}
-	fmt.Println("This program monitors time changes, it's advisable to run it in a container for testing.")
+	fmt.Println("This program monitors time changes, it's advisable to run it in a virtual machine for testing.")
 	fmt.Println("Try changing time and see if it'll generate any updates.")
 	fmt.Println("It'll automatically shutdown when you get three time changes.")
 	i := 0


### PR DESCRIPTION
It suggests to change time within a docker container,
but it'll actually change system time, because we give
that capability to the container.

Solution: rewrite the advice to use a virtual machine
and provide a Vagrant setup for that, as well as instructions.