### PR TITLE
Problem: tracking mutex unlocking patterns

### DIFF
--- a/pkg/event/fanout.go
+++ b/pkg/event/fanout.go
@@ -25,14 +25,14 @@ func NewFanOut() *FanOut {
 
 func (f *FanOut) ConsumeEvent(ev Event) (result ConsumptionResult, err error) {
 	f.eventConsumersLock.RLock()
+	defer f.eventConsumersLock.RUnlock()
 	result, err = ForwardEvent(ev, &f.eventConsumers)
-	f.eventConsumersLock.RUnlock()
 	return
 }
 
 func (f *FanOut) RegisterEventConsumer(ev Consumer) (err error) {
 	f.eventConsumersLock.Lock()
+	defer f.eventConsumersLock.Unlock()
 	f.eventConsumers = append(f.eventConsumers, ev)
-	f.eventConsumersLock.Unlock()
 	return
 }

--- a/pkg/expression/engines.go
+++ b/pkg/expression/engines.go
@@ -18,17 +18,17 @@ var enginesMap = make(map[string]func(ctx context.Context) Engine)
 
 func RegisterEngine(url string, engine func(ctx context.Context) Engine) {
 	enginesLock.Lock()
+	defer enginesLock.Unlock()
 	enginesMap[url] = engine
-	enginesLock.Unlock()
 }
 
 func GetEngine(ctx context.Context, url string) (engine Engine) {
 	enginesLock.RLock()
+	defer enginesLock.RUnlock()
 	if engineConstructor, ok := enginesMap[url]; ok {
 		engine = engineConstructor(ctx)
 	} else {
 		engine = enginesMap["http://www.w3.org/1999/XPath"](ctx)
 	}
-	enginesLock.RUnlock()
 	return
 }

--- a/pkg/flow_node/activity/harness.go
+++ b/pkg/flow_node/activity/harness.go
@@ -48,17 +48,17 @@ type Harness struct {
 
 func (node *Harness) ConsumeEvent(ev event.Event) (result event.ConsumptionResult, err error) {
 	node.eventConsumersLock.RLock()
+	defer node.eventConsumersLock.RUnlock()
 	if atomic.LoadInt32(&node.active) == 1 {
 		result, err = event.ForwardEvent(ev, &node.eventConsumers)
 	}
-	node.eventConsumersLock.RUnlock()
 	return
 }
 
 func (node *Harness) RegisterEventConsumer(consumer event.Consumer) (err error) {
 	node.eventConsumersLock.Lock()
+	defer node.eventConsumersLock.Unlock()
 	node.eventConsumers = append(node.eventConsumers, consumer)
-	node.eventConsumersLock.Unlock()
 	return
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -150,8 +150,8 @@ func (model *Model) ConsumeEvent(ev event.Event) (result event.ConsumptionResult
 
 func (model *Model) RegisterEventConsumer(ev event.Consumer) (err error) {
 	model.eventConsumersLock.Lock()
+	defer model.eventConsumersLock.Unlock()
 	model.eventConsumers = append(model.eventConsumers, ev)
-	model.eventConsumersLock.Unlock()
 	return
 }
 

--- a/pkg/process/instance/instance.go
+++ b/pkg/process/instance/instance.go
@@ -65,8 +65,8 @@ func (instance *Instance) ConsumeEvent(ev event.Event) (result event.Consumption
 
 func (instance *Instance) RegisterEventConsumer(ev event.Consumer) (err error) {
 	instance.eventConsumersLock.Lock()
+	defer instance.eventConsumersLock.Unlock()
 	instance.eventConsumers = append(instance.eventConsumers, ev)
-	instance.eventConsumersLock.Unlock()
 	return
 }
 


### PR DESCRIPTION
Some of the code has branching with its own unlocking
of mutexes. This code is error-prone as it's easy to
forget to unlock.

Solution: use deferred unlocks where feasible

Previous implementation was based on a now-outdated knowledge
that deferrals are slower. As it was pointed out in #68, this is
no longer true as of Go 1.14. My own measurements seem to confirm
this as well.

So, where it was reasonable, I've rewritten unlocking to happen in
deferred statements.